### PR TITLE
fix(multi-select): unexpected scroll issues and close event

### DIFF
--- a/components/Form/MultiSelectInput/Options/Option.jsx
+++ b/components/Form/MultiSelectInput/Options/Option.jsx
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React, {useCallback} from 'react';
 import PropTypes from 'prop-types';
 
 import CheckboxInput from '../../CheckboxInput';
@@ -37,9 +37,13 @@ const Option = ({
         [styles.disabled]: disabled,
     });
 
+    // Disable pointer events on the checkbox wrapper to prevent the native focus behavior of the browser.
+    // Without this, clicking the checkbox would try to focus the absolutely positioned input (see CheckboxInput) causing unexpected scroll behavior
     return (
         <div className={className} onClick={!disabled ? onClick : undefined}>
-            <CheckboxInput checked={selected} disabled={disabled} />
+            <div style={{ pointerEvents: 'none' }}>
+                <CheckboxInput checked={selected} disabled={disabled} />
+            </div>
             {label}
         </div>
     );

--- a/components/Form/MultiSelectInput/SelectControl/index.jsx
+++ b/components/Form/MultiSelectInput/SelectControl/index.jsx
@@ -33,10 +33,9 @@ export const Label = ({
         >
             <div className={styles.label}>{value}</div>
             {editable &&
-                <div className={styles.close}>
+                <div className={styles.close} onClick={onCloseClick}>
                     <IoClose
                         className={styles.icon}
-                        onClick={onCloseClick}
                     />
                 </div>
             }


### PR DESCRIPTION
- [x] Use onClick on close wrapper div instead of only on icon.
- [x] Fix unexpected scroll issue when clicking checkbox in options.