### PR TITLE
fix(select): prevent focus when disabled and reset focused option state

### DIFF
--- a/components/Form/SelectInput/index.jsx
+++ b/components/Form/SelectInput/index.jsx
@@ -140,10 +140,11 @@ export default class Select extends PureComponent {
             if(!this.props.onInputChange) {
                 const options = this.filterOptions(this.state.searchValue);
                 this.setState({
-                    options: options,
+                  options: options,
+                  focusedItem: this.props.value ?? this.props.defaultValue ?? this.props.options?.[0],
                 });
             } else {
-                this.setState({ options: this.props.options });
+                this.setState({ options: this.props.options, focusedItem: this.props.value ?? this.props.defaultValue ?? this.props.options?.[0] });
             }
         }
 
@@ -212,9 +213,9 @@ export default class Select extends PureComponent {
             const {focusedItem} = this.state;
             if(focusedItem) {
                 this.setState({selectedItem: focusedItem});
-                this.handleChangeCallback({name: this.props.name, option: focusedItem});
+                this.handleChangeCallback({ name: this.props.name, option: focusedItem });
+                this.hideOption();
             }
-
         }
     }
 
@@ -228,9 +229,11 @@ export default class Select extends PureComponent {
     };
 
     handleSelectFocus = (event) => {
-        event.stopPropagation();
-        this.setState({expanded: true, locked: true});
-        setTimeout(() => this.setState({locked: false}), 300);
+        if (!this.props.disabled) {
+            event.stopPropagation();
+            this.setState({expanded: true, locked: true});
+            setTimeout(() => this.setState({ locked: false }), 300);
+        }
     }
 
     handleItemFocus = ({item}) => {
@@ -312,7 +315,7 @@ export default class Select extends PureComponent {
                 [styles.disabled]: disabled,
             },
             _className
-    );
+      );
 
         const errMsg = this.getErrorMessage();
 
@@ -321,7 +324,7 @@ export default class Select extends PureComponent {
                 <div
                     ref={this.wrapperRef}
                     className={className}
-                    tabIndex="0"
+                    tabIndex={disabled ? undefined : "0"}
                     onClick={this.handleCaretClick}
                     onKeyDown={this.handleKeyDown}
                     onFocusCapture={this.handleSelectFocus}

--- a/components/Popup/index.jsx
+++ b/components/Popup/index.jsx
@@ -110,7 +110,7 @@ const Popup = (props) => {
     const transformWrapperRect = useCallback((rect) => {
         const [anchorVertical, anchorHorizontal] = anchorOrigin.trim().split(' ');
         const [transformVertical, transformHorizontal] = transformOrigin.trim().split(' ');
-        
+
         const topAnchor = {
             'top': rect.top,
             'center': (rect.top + rect.bottom)/2,


### PR DESCRIPTION
- [x] Prevent focus for select inputs when disabled.
- [x] Hide options when focused item is selected via Enter key.
- [x] Reset focused item when options or search values change.

Fixes #3.