### PR TITLE
fix(build): ship plain css and expose used internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# @nepware/react-arsenal
+
+Shared React component and utility library.
+
+## Installation
+
+```sh
+npm install @nepware/react-arsenal
+# or
+pnpm add @nepware/react-arsenal
+```
+
+Peer dependencies: `react >=18`, `react-dom >=18`, and optionally `react-router-dom ^5`.
+
+## Usage
+
+Everything is imported by subpath so bundlers only pull in what you use:
+
+```jsx
+import Dropdown from '@nepware/react-arsenal/components/Dropdown';
+import Modal from '@nepware/react-arsenal/components/Modal';
+import { defaultLocalizer } from '@nepware/react-arsenal/components/I18n';
+```
+
+## Styling
+
+Component styles are pre-compiled with scoped class names baked into the shipped
+JS, and emitted as plain `.css` files. There are two ways to consume them, and
+they are not mutually exclusive.
+
+### 1. Automatic (default, zero-config)
+
+Each component's dist module side-effect-imports its own compiled stylesheet, so
+just importing a component pulls in its CSS. No bundler configuration is needed
+with Vite, webpack, or any bundler that follows the `sideEffects` field. This is
+the recommended mode for standard client bundling and keeps the CSS payload
+scoped to the components you actually use.
+
+### 2. Aggregated stylesheet (SSR / RSC / test environments)
+
+For environments that do not evaluate the side-effect CSS imports (some
+server-side rendering, React Server Components, or test setups), import the
+single aggregated stylesheet once at your app root:
+
+```js
+import '@nepware/react-arsenal/styles.css';
+```
+
+This ships every component's compiled styles in one file. The class names match
+the shipped JS verbatim, so no re-scoping or CSS-module handling is required.

--- a/components/Form/DragDropFileInput/index.tsx
+++ b/components/Form/DragDropFileInput/index.tsx
@@ -282,4 +282,5 @@ const DragDropFileInput: React.FC<DragDropFileInputProps> = (props) => {
 
 export default DragDropFileInput;
 
+export { fileMatchSize } from './utils';
 export * from './types';

--- a/components/Form/SliderInput/index.tsx
+++ b/components/Form/SliderInput/index.tsx
@@ -451,4 +451,5 @@ function SliderInput<T extends string | number>(props: SliderInputProps<T>) {
 
 export default SliderInput;
 
+export { default as useDrag } from './useDrag';
 export type { SliderInputProps } from './types';

--- a/components/I18n/index.tsx
+++ b/components/I18n/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { Language } from './types';
 
-import { I18nContext, useI18nContext, defaultContext } from './i18nContext';
+import { I18nContext, useI18nContext, defaultContext, defaultLocalizer } from './i18nContext';
 import Localize from './Localize';
 import type { I18nProviderProps } from './types';
 
@@ -34,6 +34,6 @@ const I18nProvider = (props: I18nProviderProps) => {
     return <I18nContext.Provider value={contextValue}>{children}</I18nContext.Provider>;
 };
 
-export { useI18nContext, Localize };
+export { useI18nContext, Localize, defaultLocalizer };
 
 export default I18nProvider;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ],
     "exports": {
         "./package.json": "./package.json",
+        "./styles.css": "./dist/styles.css",
         "./cs": {
             "types": "./dist/cs.d.ts",
             "default": "./dist/cs.js"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,30 @@ import { fileURLToPath } from 'node:url';
 
 import react from '@vitejs/plugin-react';
 import { globSync } from 'tinyglobby';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
 const root = dirname(fileURLToPath(import.meta.url));
+
+// Aggregate every per-component stylesheet into a single `dist/styles.css`.
+const bundleStyles = (): Plugin => ({
+    name: 'ra-bundle-styles',
+    generateBundle(_options, bundle) {
+        const css = Object.keys(bundle)
+            .filter((fileName) => fileName.endsWith('.css'))
+            .sort()
+            .map((fileName) => {
+                const asset = bundle[fileName];
+                if (asset.type !== 'asset') return '';
+                return typeof asset.source === 'string' ? asset.source : new TextDecoder().decode(asset.source);
+            })
+            .join('\n');
+        if (css) {
+            this.emitFile({ type: 'asset', fileName: 'styles.css', source: css });
+        }
+    },
+});
 
 // Every public source file becomes its own entry so the built `dist/` mirrors
 // the source tree and consumers keep importing by subpath
@@ -25,6 +44,7 @@ export default defineConfig({
     plugins: [
         react(),
         libInjectCss(),
+        bundleStyles(),
         dts({
             tsconfigPath: 'tsconfig.build.json',
             include: ['auth', 'components', 'hooks', 'services', 'utils', 'cs.ts', 'scss.d.ts'],
@@ -54,7 +74,14 @@ export default defineConfig({
                 preserveModules: true,
                 preserveModulesRoot: root,
                 entryFileNames: '[name].js',
-                assetFileNames: 'assets/[name][extname]',
+                // Drop `.module` so consumer bundlers do not re-scope pre-compiled styles.
+                assetFileNames: (info) => {
+                    const name = info.name ?? '';
+                    if (name.endsWith('.css')) {
+                        return `assets/${name.replace(/\.module\.css$/, '.css')}`;
+                    }
+                    return 'assets/[name][extname]';
+                },
             },
         },
     },


### PR DESCRIPTION
- [x] Emit compiled styles as plain .css so bundlers do not re-scope them.
- [x] Add aggregated dist/styles.css via ./styles.css export for SSR/RSC.
- [x] Re-export defaultLocalizer, fileMatchSize and useDrag publicly.
- [x] Document automatic and aggregated style consumption in README.