### PR TITLE
feat(table): add opt-in column sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ import Dropdown from '@nepware/react-arsenal/components/Dropdown';
 import Modal from '@nepware/react-arsenal/components/Modal';
 import { defaultLocalizer } from '@nepware/react-arsenal/components/I18n';
 ```
-
 ## Styling
 
 Component styles are pre-compiled with scoped class names baked into the shipped

--- a/__tests__/components/Table/Hierarchical.test.tsx
+++ b/__tests__/components/Table/Hierarchical.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import HierarchicalTable, {
     type Column,
     type Hierarchical,
+    type HierarchicalTableProps,
 } from '../../../components/Table/Hierarchical';
 import { buildHierarchy } from '../../../utils';
 
@@ -580,6 +581,276 @@ describe('HierarchicalTable', () => {
             );
 
             expect(screen.getByText('No item to display')).toBeInTheDocument();
+        });
+    });
+
+    describe('Sorting', () => {
+        const sortableColumns: Column<Hierarchical<OrgNode>>[] = [
+            { Header: 'Title', accessor: 'title', sortable: true },
+            { Header: 'Count', accessor: 'count', sortable: true },
+            { Header: 'Info', accessor: 'info' },
+        ];
+
+        const buildSortableData = (): Hierarchical<OrgNode>[] => [
+            {
+                id: 1,
+                title: 'Engineering',
+                count: 42,
+                active: true,
+                tags: ['eng'],
+                info: { code: 'ENG' },
+                level: 0,
+                children: [
+                    {
+                        id: 2,
+                        title: 'Frontend',
+                        count: 10,
+                        active: false,
+                        tags: [],
+                        info: null,
+                        level: 1,
+                        children: [],
+                    },
+                    {
+                        id: 3,
+                        title: 'Backend',
+                        count: 12,
+                        active: true,
+                        tags: ['api'],
+                        info: { code: 'BE' },
+                        level: 1,
+                        children: [
+                            {
+                                id: 4,
+                                title: 'Platform',
+                                count: 3,
+                                active: true,
+                                tags: [],
+                                info: null,
+                                level: 2,
+                                children: [],
+                            },
+                            {
+                                id: 5,
+                                title: 'Database',
+                                count: 9,
+                                active: true,
+                                tags: [],
+                                info: null,
+                                level: 2,
+                                children: [],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                id: 6,
+                title: 'Sales',
+                count: 8,
+                active: false,
+                tags: [],
+                info: null,
+                level: 0,
+                children: [],
+            },
+        ];
+
+        const dataRows = () => screen.getAllByRole('row').slice(1);
+        const renderedTitles = () =>
+            dataRows().map((row) => row.querySelectorAll('td')[0].textContent);
+        const renderedLevels = () =>
+            dataRows().map((row) =>
+                row.querySelectorAll('td')[0].style.getPropertyValue('--row-level'),
+            );
+
+        const renderSortableTable = (
+            props: Partial<HierarchicalTableProps<OrgNode>> = {},
+            sortableData: Hierarchical<OrgNode>[] = buildSortableData(),
+        ) =>
+            render(
+                <HierarchicalTable
+                    data={sortableData}
+                    columns={sortableColumns}
+                    keyExtractor={keyExtractor}
+                    renderDataItem={renderDataItem}
+                    hierarchyOptions={{ initialExpandedLevel: 2 }}
+                    {...props}
+                />,
+            );
+
+        it('leaves every level in its original order until a column is sorted', () => {
+            renderSortableTable();
+
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Frontend',
+                'Backend',
+                'Platform',
+                'Database',
+                'Sales',
+            ]);
+            expect(
+                screen.getByRole('columnheader', { name: /Title/ }),
+            ).toHaveAttribute('aria-sort', 'none');
+        });
+
+        it('sorts root nodes when a sortable header is clicked', () => {
+            renderSortableTable({ hierarchyOptions: { initialExpandedLevel: 0 } });
+
+            fireEvent.click(screen.getByRole('button', { name: /Count/ }));
+
+            expect(renderedTitles()).toEqual(['Sales', 'Engineering']);
+            expect(screen.getByRole('columnheader', { name: /Count/ })).toHaveAttribute(
+                'aria-sort',
+                'ascending',
+            );
+        });
+
+        it('sorts siblings at every depth with the same sort state', () => {
+            renderSortableTable();
+
+            fireEvent.click(screen.getByRole('button', { name: /Title/ }));
+
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Backend',
+                'Database',
+                'Platform',
+                'Frontend',
+                'Sales',
+            ]);
+        });
+
+        it('reverses siblings at every depth on the descending step of the cycle', () => {
+            renderSortableTable();
+            const titleSortButton = screen.getByRole('button', { name: /Title/ });
+
+            fireEvent.click(titleSortButton);
+            fireEvent.click(titleSortButton);
+
+            expect(renderedTitles()).toEqual([
+                'Sales',
+                'Engineering',
+                'Frontend',
+                'Backend',
+                'Platform',
+                'Database',
+            ]);
+
+            fireEvent.click(titleSortButton);
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Frontend',
+                'Backend',
+                'Platform',
+                'Database',
+                'Sales',
+            ]);
+        });
+
+        it('keeps children nested under their own parent when sorting', () => {
+            renderSortableTable();
+
+            fireEvent.click(screen.getByRole('button', { name: /Title/ }));
+
+            expect(renderedLevels()).toEqual(['0rem', '1rem', '2rem', '2rem', '1rem', '0rem']);
+
+            const backendRow = screen.getByText('Backend').closest('tr') as HTMLElement;
+            fireEvent.click(getToggleIcon(backendRow)!);
+            expect(screen.queryByText('Database')).not.toBeInTheDocument();
+            expect(screen.queryByText('Platform')).not.toBeInTheDocument();
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Backend',
+                'Frontend',
+                'Sales',
+            ]);
+        });
+
+        it('ignores sort state pointing at a column that is not sortable', () => {
+            renderSortableTable({ defaultSort: { accessor: 'info', direction: 'asc' } });
+
+            expect(screen.getAllByRole('button')).toHaveLength(2);
+            expect(screen.getByRole('columnheader', { name: /Info/ })).not.toHaveAttribute(
+                'aria-sort',
+            );
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Frontend',
+                'Backend',
+                'Platform',
+                'Database',
+                'Sales',
+            ]);
+        });
+
+        it('orders every level from defaultSort on the first render', () => {
+            renderSortableTable({ defaultSort: { accessor: 'count', direction: 'desc' } });
+
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Backend',
+                'Database',
+                'Platform',
+                'Frontend',
+                'Sales',
+            ]);
+        });
+
+        it('honours a custom sortAccessor at every depth', () => {
+            renderSortableTable({
+                columns: [
+                    {
+                        Header: 'Info',
+                        accessor: 'info.code',
+                        sortable: true,
+                        sortAccessor: (item) => item.info?.code ?? null,
+                    },
+                ],
+                defaultSort: { accessor: 'info.code', direction: 'asc' },
+            });
+
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Backend',
+                'Platform',
+                'Database',
+                'Frontend',
+                'Sales',
+            ]);
+        });
+
+        it('reports sort changes and leaves data untouched when manualSort is set', () => {
+            const handleSortChange = vi.fn();
+            renderSortableTable({ manualSort: true, onSortChange: handleSortChange });
+
+            fireEvent.click(screen.getByRole('button', { name: /Title/ }));
+
+            expect(handleSortChange).toHaveBeenCalledWith({
+                accessor: 'title',
+                direction: 'asc',
+            });
+            expect(renderedTitles()).toEqual([
+                'Engineering',
+                'Frontend',
+                'Backend',
+                'Platform',
+                'Database',
+                'Sales',
+            ]);
+        });
+
+        it('does not mutate the data it was given', () => {
+            const sortableData = buildSortableData();
+            const originalData = JSON.stringify(sortableData);
+
+            renderSortableTable({}, sortableData);
+            const titleSortButton = screen.getByRole('button', { name: /Title/ });
+            fireEvent.click(titleSortButton);
+            fireEvent.click(titleSortButton);
+
+            expect(JSON.stringify(sortableData)).toBe(originalData);
         });
     });
 });

--- a/__tests__/components/Table/sorting.test.tsx
+++ b/__tests__/components/Table/sorting.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+
+import Table, { type Column } from '../../../components/Table';
+
+interface Item {
+    id: number;
+    name: string;
+    score: number;
+    department: { title: string };
+}
+
+const data: Item[] = [
+    { id: 1, name: 'Gamma', score: 7, department: { title: 'Radiology' } },
+    { id: 2, name: 'Alpha', score: 42, department: { title: 'Cardiology' } },
+    { id: 3, name: 'Beta', score: 0, department: { title: 'Neurology' } },
+];
+
+const columns: Column<Item>[] = [
+    { Header: 'Name', accessor: 'name', sortable: true },
+    { Header: 'Score', accessor: 'score' },
+];
+
+const keyExtractor = (item: Item) => item.id;
+
+const renderedNames = () =>
+    screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => row.querySelectorAll('td')[0].textContent);
+
+const nameHeader = () => screen.getByRole('columnheader', { name: /Name/ });
+
+describe('Table sorting', () => {
+    it('renders a sort control only for sortable columns', () => {
+        render(<Table data={data} columns={columns} keyExtractor={keyExtractor} />);
+
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+        expect(screen.getByRole('button', { name: /Name/ })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /Score/ })).not.toHaveAttribute('aria-sort');
+    });
+
+    it('leaves data in its original order until a column is sorted', () => {
+        render(<Table data={data} columns={columns} keyExtractor={keyExtractor} />);
+
+        expect(renderedNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('cycles ascending, descending and back to unsorted on repeated clicks', () => {
+        render(<Table data={data} columns={columns} keyExtractor={keyExtractor} />);
+        const sortButton = screen.getByRole('button', { name: /Name/ });
+
+        fireEvent.click(sortButton);
+        expect(renderedNames()).toEqual(['Alpha', 'Beta', 'Gamma']);
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'ascending');
+
+        fireEvent.click(sortButton);
+        expect(renderedNames()).toEqual(['Gamma', 'Beta', 'Alpha']);
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'descending');
+
+        fireEvent.click(sortButton);
+        expect(renderedNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('sorts via the keyboard when the header control is focused', async () => {
+        const user = userEvent.setup();
+        render(<Table data={data} columns={columns} keyExtractor={keyExtractor} />);
+
+        await user.tab();
+        expect(screen.getByRole('button', { name: /Name/ })).toHaveFocus();
+
+        await user.keyboard('{Enter}');
+        expect(renderedNames()).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+        await user.keyboard(' ');
+        expect(renderedNames()).toEqual(['Gamma', 'Beta', 'Alpha']);
+    });
+
+    it('starts from defaultSort when sorting is uncontrolled', () => {
+        render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                defaultSort={{ accessor: 'name', direction: 'desc' }}
+            />,
+        );
+
+        expect(renderedNames()).toEqual(['Gamma', 'Beta', 'Alpha']);
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('sorts by sortAccessor when the value is not reachable through the accessor', () => {
+        const departmentColumns: Column<Item>[] = [
+            {
+                Header: 'Department',
+                accessor: 'department.title',
+                sortable: true,
+                sortAccessor: (item) => item.department.title,
+            },
+        ];
+        render(
+            <Table
+                data={data}
+                columns={departmentColumns}
+                keyExtractor={keyExtractor}
+                defaultSort={{ accessor: 'department.title', direction: 'asc' }}
+                renderDataItem={({ item }) => item.name}
+            />,
+        );
+
+        expect(renderedNames()).toEqual(['Alpha', 'Beta', 'Gamma']);
+    });
+
+    it('sorts with a custom comparator when one is provided', () => {
+        const scoreColumns: Column<Item>[] = [
+            {
+                Header: 'Name',
+                accessor: 'name',
+                sortable: true,
+                sortComparator: (firstItem, secondItem) => firstItem.score - secondItem.score,
+            },
+        ];
+        render(
+            <Table
+                data={data}
+                columns={scoreColumns}
+                keyExtractor={keyExtractor}
+                defaultSort={{ accessor: 'name', direction: 'asc' }}
+            />,
+        );
+
+        expect(renderedNames()).toEqual(['Beta', 'Gamma', 'Alpha']);
+    });
+
+    it('sorts the whole dataset before applying pagination', () => {
+        render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                maxRows={1}
+                defaultSort={{ accessor: 'name', direction: 'asc' }}
+            />,
+        );
+
+        expect(renderedNames()).toEqual(['Alpha']);
+    });
+
+    it('reports sort changes without reordering data when manualSort is set', () => {
+        const handleSortChange = vi.fn();
+        render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                sort={null}
+                manualSort
+                onSortChange={handleSortChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /Name/ }));
+
+        expect(handleSortChange).toHaveBeenCalledWith({ accessor: 'name', direction: 'asc' });
+        expect(renderedNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+    });
+
+    it('keeps the controlled sort state in charge of the indicator', () => {
+        const { rerender } = render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                sort={{ accessor: 'name', direction: 'desc' }}
+                onSortChange={vi.fn()}
+            />,
+        );
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'descending');
+
+        fireEvent.click(screen.getByRole('button', { name: /Name/ }));
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'descending');
+
+        rerender(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                sort={null}
+                onSortChange={vi.fn()}
+            />,
+        );
+        expect(nameHeader()).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('never makes the selection column sortable', () => {
+        render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                selectable
+                selectedItems={[]}
+                onSelectedItemsChange={vi.fn()}
+            />,
+        );
+
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+        expect(screen.getAllByRole('columnheader')[0]).not.toHaveAttribute('aria-sort');
+    });
+
+    it('does not mutate the data prop', () => {
+        const originalOrder = [...data];
+        render(
+            <Table
+                data={data}
+                columns={columns}
+                keyExtractor={keyExtractor}
+                defaultSort={{ accessor: 'name', direction: 'asc' }}
+            />,
+        );
+
+        expect(data).toEqual(originalOrder);
+    });
+});

--- a/components/Table/Hierarchical/index.tsx
+++ b/components/Table/Hierarchical/index.tsx
@@ -7,11 +7,14 @@ import type {
     Hierarchical,
     HierarchicalTableProps,
     KeyExtractor,
+    SortState,
     TableRenderDataItem,
     TableRowRenderer,
 } from './types';
 import Table from '..';
+import { getSortedHierarchicalData } from '../sort';
 import cs from '../../../cs';
+import useControlledState from '../../../hooks/useControlledState';
 
 /**
  * Recursively collects keys of items that should be initially expanded based on initialExpandedLevel.
@@ -54,6 +57,7 @@ function HierarchicalTable<T, C extends string = 'children', L extends string = 
 ) {
     const {
         data,
+        columns,
         bodyRowParentClassName,
         bodyRowChildClassName,
         bodyRowLastChildClassName,
@@ -66,6 +70,10 @@ function HierarchicalTable<T, C extends string = 'children', L extends string = 
         bodyRowClassName,
         dataClassName,
         rowSpacingHeight,
+        sort,
+        defaultSort = null,
+        onSortChange,
+        manualSort = false,
         ...tableProps
     } = props;
 
@@ -89,6 +97,18 @@ function HierarchicalTable<T, C extends string = 'children', L extends string = 
 
         return data as Hierarchical<T, C, L>[];
     }, [hierarchyOptions, data, levelKey, childrenKey, keyExtractor]);
+
+    const [sortState, setSortState] = useControlledState<SortState | null>(defaultSort, {
+        value: sort,
+        onChange: onSortChange,
+    });
+
+    const sortedTableData = useMemo(() => {
+        if (manualSort) {
+            return tableData;
+        }
+        return getSortedHierarchicalData(tableData, sortState, columns, childrenKey);
+    }, [tableData, sortState, columns, childrenKey, manualSort]);
 
     const [expandedKeys, setExpandedKeys] = useState(() =>
         collectInitiallyExpandedKeys(
@@ -181,7 +201,8 @@ function HierarchicalTable<T, C extends string = 'children', L extends string = 
     return (
         <Table
             {...tableProps}
-            data={tableData}
+            columns={columns}
+            data={sortedTableData}
             rowRenderer={renderHierarchicalRow}
             keyExtractor={keyExtractor}
             onRowClick={onRowClick}
@@ -189,6 +210,9 @@ function HierarchicalTable<T, C extends string = 'children', L extends string = 
             bodyRowClassName={bodyRowClassName}
             dataClassName={dataClassName}
             rowSpacingHeight={rowSpacingHeight}
+            sort={sortState}
+            onSortChange={setSortState}
+            manualSort
         />
     );
 }
@@ -221,7 +245,7 @@ function HierarchicalRow<T, C extends string = 'children', L extends string = 'l
     item: Hierarchical<T, C, L>;
     index: number;
     onClick?: (item: Hierarchical<T, C, L>) => void;
-    columns: Column[];
+    columns: Column<Hierarchical<T, C, L>>[];
     className?: string;
     dataClassName?: string;
     parentClassName?: string;

--- a/components/Table/README.md
+++ b/components/Table/README.md
@@ -1,0 +1,79 @@
+## Table sorting
+
+Sorting is opt-in per column. Mark a column `sortable` and its header becomes a
+button that cycles ascending → descending → unsorted, with `aria-sort` kept in
+sync on the `th`. Everything else about the table is unchanged.
+
+```jsx
+const columns = [
+    { Header: 'Name', accessor: 'name', sortable: true },
+    { Header: 'Score', accessor: 'score' },
+];
+
+<Table data={data} columns={columns} keyExtractor={(item) => item.id} />;
+```
+
+By default the table sorts `data` itself, before pagination is applied, so the
+whole dataset is ordered rather than just the visible page.
+
+`accessor` values that are not plain keys of the data item (nested or indexed
+paths) cannot be read by the default comparator. Provide `sortAccessor` to
+return the value to compare, or `sortComparator` for full control:
+
+```jsx
+const columns = [
+    {
+        Header: 'Department',
+        accessor: 'department.title',
+        sortable: true,
+        sortAccessor: (item) => item.department.title,
+    },
+    {
+        Header: 'Priority',
+        accessor: 'priority',
+        sortable: true,
+        sortComparator: (firstItem, secondItem) => firstItem.rank - secondItem.rank,
+    },
+];
+```
+
+### Server-side sorting
+
+Pass `manualSort` when the backend orders the rows. The table then renders the
+indicators and reports changes through `onSortChange` without reordering `data`.
+Combine it with `sort` to control the state yourself:
+
+```jsx
+<Table
+    data={data}
+    columns={columns}
+    keyExtractor={(item) => item.id}
+    manualSort
+    sort={sort}
+    onSortChange={setSort}
+/>
+```
+
+Providing `sort` makes sorting controlled; omit it and pass `defaultSort` to
+choose the initial order while letting the table own the state.
+
+### Hierarchical tables
+
+`Table/Hierarchical` takes the same props. Sorting there is hierarchy-aware: the
+sort state is applied to siblings at every depth, so each node's children are
+ordered among themselves and the parent-child structure never changes.
+
+```jsx
+<HierarchicalTable
+    data={data}
+    columns={columns}
+    keyExtractor={(item) => item.id}
+    hierarchyOptions={{ initialExpandedLevel: 2 }}
+/>
+```
+
+`sort`, `defaultSort`, `onSortChange` and `manualSort` behave as they do on the
+flat table. With `manualSort` the tree is rendered exactly as provided, so the
+backend is responsible for ordering each level.
+
+

--- a/components/Table/index.tsx
+++ b/components/Table/index.tsx
@@ -1,10 +1,14 @@
 import React, { useMemo, useCallback, useRef, useEffect, type JSX } from 'react';
 
+import { MdArrowDownward, MdArrowUpward, MdUnfoldMore } from 'react-icons/md';
+
 import styles from './styles.module.scss';
-import type { TableProps, TableRenderDataItem } from './types';
+import { getNextSortDirection, getSortedData } from './sort';
+import type { Column, SortDirection, SortState, TableProps, TableRenderDataItem } from './types';
 import CheckboxInput from '../Form/CheckboxInput';
 import List, { type ListRenderItem } from '../List';
 import cs from '../../cs';
+import useControlledState from '../../hooks/useControlledState';
 
 const tableDataStyle = {
     '--row-level': '0rem',
@@ -59,6 +63,49 @@ function Row<T>({
     );
 }
 
+const ariaSortValues = {
+    asc: 'ascending',
+    desc: 'descending',
+} as const;
+
+const sortIcons = {
+    asc: MdArrowUpward,
+    desc: MdArrowDownward,
+};
+
+function SortableHeaderItem({
+    column,
+    sortDirection,
+    onToggleSort,
+    iconClassName,
+    children,
+}: {
+    column: Column;
+    sortDirection: SortDirection | null;
+    onToggleSort: (accessor: string) => void;
+    iconClassName?: string;
+    children: React.ReactNode;
+}) {
+    const handleClick = useCallback(
+        () => onToggleSort(column.accessor),
+        [onToggleSort, column.accessor],
+    );
+
+    const SortIcon = sortDirection ? sortIcons[sortDirection] : MdUnfoldMore;
+
+    return (
+        <button type="button" className={styles.sortButton} onClick={handleClick}>
+            {children}
+            <SortIcon
+                aria-hidden
+                className={cs(styles.sortIcon, iconClassName, {
+                    [styles.sortIconInactive]: !sortDirection,
+                })}
+            />
+        </button>
+    );
+}
+
 function Table<T>(props: TableProps<T>) {
     const {
         className,
@@ -88,7 +135,26 @@ function Table<T>(props: TableProps<T>) {
         selectedItems = [],
         onSelectedItemsChange,
         selectedRowClassName = '',
+        sort,
+        defaultSort = null,
+        onSortChange,
+        manualSort = false,
+        sortIconClassName,
     } = props;
+
+    const [sortState, setSortState] = useControlledState<SortState | null>(defaultSort, {
+        value: sort,
+        onChange: onSortChange,
+    });
+
+    const handleToggleSort = useCallback(
+        (accessor: string) => {
+            const currentDirection = sortState?.accessor === accessor ? sortState.direction : null;
+            const nextDirection = getNextSortDirection(currentDirection);
+            setSortState(nextDirection ? { accessor, direction: nextDirection } : null);
+        },
+        [sortState, setSortState],
+    );
 
     const tableColumns = useMemo(() => {
         if (!selectable) {
@@ -97,13 +163,20 @@ function Table<T>(props: TableProps<T>) {
         return [{ Header: '', accessor: 'select' }, ...columns];
     }, [columns, selectable]);
 
-    const visibleData = useMemo(() => {
-        if (controlled) {
+    const sortedData = useMemo(() => {
+        if (manualSort || !sortState) {
             return data;
         }
+        return getSortedData(data, sortState, columns);
+    }, [data, columns, sortState, manualSort]);
+
+    const visibleData = useMemo(() => {
+        if (controlled) {
+            return sortedData;
+        }
         const initIndex = (page - 1) * maxRows;
-        return data.slice(initIndex, initIndex + maxRows);
-    }, [controlled, data, maxRows, page]);
+        return sortedData.slice(initIndex, initIndex + maxRows);
+    }, [controlled, sortedData, maxRows, page]);
 
     useEffect(() => {
         if (page && maxRows && selectable) {
@@ -137,7 +210,11 @@ function Table<T>(props: TableProps<T>) {
     const headerCheckboxRef = useRef<HTMLInputElement>(null);
     const Header = useMemo(() => {
         if (renderHeader) {
-            return renderHeader({ columns: tableColumns });
+            return renderHeader({
+                columns: tableColumns,
+                sort: sortState,
+                onSortChange: setSortState,
+            });
         }
         return (
             <thead className={cs(styles.head, headerClassName)}>
@@ -161,9 +238,35 @@ function Table<T>(props: TableProps<T>) {
                                 </th>
                             );
                         }
+                        const content = renderHeaderItem
+                            ? renderHeaderItem({ column: col })
+                            : col.Header;
+
+                        if (!col.sortable) {
+                            return (
+                                <th key={idx} className={cs(styles.data, headerItemClassName)}>
+                                    {content}
+                                </th>
+                            );
+                        }
+
+                        const sortDirection =
+                            sortState?.accessor === col.accessor ? sortState.direction : null;
+
                         return (
-                            <th key={idx} className={cs(styles.data, headerItemClassName)}>
-                                {renderHeaderItem ? renderHeaderItem({ column: col }) : col.Header}
+                            <th
+                                key={idx}
+                                className={cs(styles.data, headerItemClassName)}
+                                aria-sort={sortDirection ? ariaSortValues[sortDirection] : 'none'}
+                            >
+                                <SortableHeaderItem
+                                    column={col}
+                                    sortDirection={sortDirection}
+                                    onToggleSort={handleToggleSort}
+                                    iconClassName={sortIconClassName}
+                                >
+                                    {content}
+                                </SortableHeaderItem>
                             </th>
                         );
                     })}
@@ -181,6 +284,10 @@ function Table<T>(props: TableProps<T>) {
         handleAllRowsSelectedChange,
         renderHeader,
         renderHeaderItem,
+        sortState,
+        setSortState,
+        handleToggleSort,
+        sortIconClassName,
     ]);
 
     const renderTableDataItem: TableRenderDataItem<T> = useCallback(

--- a/components/Table/sort.ts
+++ b/components/Table/sort.ts
@@ -1,0 +1,102 @@
+import type { Column, SortDirection, SortState } from './types';
+
+const sortCycle: (SortDirection | null)[] = ['asc', 'desc', null];
+
+export function getNextSortDirection(
+    currentDirection: SortDirection | null,
+): SortDirection | null {
+    const currentIndex = sortCycle.indexOf(currentDirection);
+    return sortCycle[(currentIndex + 1) % sortCycle.length];
+}
+
+export function getSortValue<T>(item: T, column: Column<T>): unknown {
+    if (column.sortAccessor) {
+        return column.sortAccessor(item);
+    }
+    return (item as Record<string, unknown>)?.[column.accessor];
+}
+
+export function compareSortValues(firstValue: unknown, secondValue: unknown): number {
+    if (firstValue === secondValue) {
+        return 0;
+    }
+    if (firstValue === null || firstValue === undefined) {
+        return 1;
+    }
+    if (secondValue === null || secondValue === undefined) {
+        return -1;
+    }
+    if (typeof firstValue === 'number' && typeof secondValue === 'number') {
+        return firstValue - secondValue;
+    }
+    if (typeof firstValue === 'boolean' && typeof secondValue === 'boolean') {
+        return Number(firstValue) - Number(secondValue);
+    }
+    if (firstValue instanceof Date && secondValue instanceof Date) {
+        return firstValue.getTime() - secondValue.getTime();
+    }
+    return String(firstValue).localeCompare(String(secondValue), undefined, {
+        numeric: true,
+        sensitivity: 'base',
+    });
+}
+
+export function getSortedColumn<T>(
+    sort: SortState | null,
+    columns: Column<T>[],
+): Column<T> | undefined {
+    if (!sort) {
+        return undefined;
+    }
+    const sortedColumn = columns.find((column) => column.accessor === sort.accessor);
+    return sortedColumn?.sortable ? sortedColumn : undefined;
+}
+
+export function getSortedData<T>(
+    data: T[],
+    sort: SortState | null,
+    columns: Column<T>[],
+): T[] {
+    const sortedColumn = getSortedColumn(sort, columns);
+    if (!sort || !sortedColumn) {
+        return data;
+    }
+
+    const directionFactor = sort.direction === 'desc' ? -1 : 1;
+    const { sortComparator } = sortedColumn;
+
+    return [...data].sort((firstItem, secondItem) => {
+        if (sortComparator) {
+            return directionFactor * sortComparator(firstItem, secondItem);
+        }
+        return (
+            directionFactor *
+            compareSortValues(
+                getSortValue(firstItem, sortedColumn),
+                getSortValue(secondItem, sortedColumn),
+            )
+        );
+    });
+}
+
+export function getSortedHierarchicalData<T>(
+    data: T[],
+    sort: SortState | null,
+    columns: Column<T>[],
+    childrenKey: string,
+): T[] {
+    if (!getSortedColumn(sort, columns)) {
+        return data;
+    }
+
+    return getSortedData(data, sort, columns).map((item) => {
+        const children = (item as Record<string, unknown>)?.[childrenKey];
+        if (!Array.isArray(children) || children.length === 0) {
+            return item;
+        }
+        return {
+            ...item,
+            [childrenKey]: getSortedHierarchicalData(children as T[], sort, columns, childrenKey),
+        };
+    });
+}

--- a/components/Table/styles.module.scss
+++ b/components/Table/styles.module.scss
@@ -32,5 +32,25 @@
   .data {
     border: 1px solid var(--color-border);
     padding: 0.5rem 0.75rem;
+
+    .sortButton {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0;
+      border: none;
+      background: none;
+      font: inherit;
+      color: inherit;
+      cursor: pointer;
+
+      .sortIcon {
+        flex-shrink: 0;
+
+        &Inactive {
+          opacity: 0.4;
+        }
+      }
+    }
   }
 }

--- a/components/Table/types.ts
+++ b/components/Table/types.ts
@@ -4,18 +4,60 @@ import type { ListRenderItemProps, KeyExtractor, ListProps } from '../List';
 
 export type { KeyExtractor };
 
-export interface Column {
-    Header: string;
+/**
+ * Direction a sorted column is ordered in.
+ * `asc` is ascending, `desc` is descending.
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Current sort applied to the table.
+ * `accessor` identifies the sorted column and `direction` its order.
+ */
+export interface SortState {
     accessor: string;
+    direction: SortDirection;
 }
 
-export type TableRenderHeader = ({ columns }: { columns: Column[] }) => React.ReactNode;
-export type TableRenderHeaderItem = ({ column }: { column: Column }) => React.ReactNode | string;
+export interface Column<T = any> {
+    Header: string;
+    accessor: string;
+    /**
+     * Whether this column can be sorted by clicking its header.
+     * Defaults to false.
+     */
+    sortable?: boolean;
+    /**
+     * Value compared by the default comparator.
+     * Defaults to `item[accessor]`.
+     */
+    sortAccessor?: (item: T) => unknown;
+    /**
+     * Ascending comparator for this column.
+     * Takes precedence over `sortAccessor` when both are provided.
+     */
+    sortComparator?: (firstItem: T, secondItem: T) => number;
+}
+
+export type TableRenderHeader<T = any> = ({
+    columns,
+    sort,
+    onSortChange,
+}: {
+    columns: Column<T>[];
+    sort?: SortState | null;
+    onSortChange?: (sort: SortState | null) => void;
+}) => React.ReactNode;
+export type TableRenderHeaderItem<T = any> = ({
+    column,
+}: {
+    column: Column<T>;
+}) => React.ReactNode | string;
 
 export type TableRenderDataItemProps<T> = {
     item: T;
     index: number;
-    column: Column;
+    column: Column<T>;
     path?: (string | number)[];
 };
 export type TableRenderDataItem<T> = ({
@@ -26,7 +68,7 @@ export type TableRenderDataItem<T> = ({
 }: TableRenderDataItemProps<T>) => React.ReactNode | string;
 
 export type TableRowRendererProps<T> = ListRenderItemProps<T> & {
-    columns: Column[];
+    columns: Column<T>[];
     isSelected: boolean;
 };
 export type TableRowRenderer<T> = (props: TableRowRendererProps<T>) => React.ReactNode | string;
@@ -72,7 +114,7 @@ export interface TableProps<T> {
      * Array of columns for the table.
      * Requires Header and accessor keys for each column
      */
-    columns: Column[];
+    columns: Column<T>[];
     /*
      * Extract key from data items.
      * Note: Avoid using index as the key for tables
@@ -83,12 +125,12 @@ export interface TableProps<T> {
      * Renderer for header.
      * @param {{columns: array}} payload - Contains the columns array of table for rendering header.
      */
-    renderHeader?: TableRenderHeader;
+    renderHeader?: TableRenderHeader<T>;
     /*
      * Renderer for each data item in header.
      * Appears as a direct child of td element.
      */
-    renderHeaderItem?: TableRenderHeaderItem;
+    renderHeaderItem?: TableRenderHeaderItem<T>;
     /*
      * Renderer for each data item in body.
      * Appears as a direct child of td element.
@@ -154,4 +196,28 @@ export interface TableProps<T> {
      * Class applied to selected row.
      */
     selectedRowClassName?: string;
+    /**
+     * Current sort state of the table. Passing this prop makes sorting controlled.
+     * `null` means controlled-and-unsorted; `undefined` leaves sorting uncontrolled.
+     */
+    sort?: SortState | null;
+    /**
+     * Sort state the table starts with when sorting is uncontrolled.
+     * Defaults to `null` (unsorted).
+     */
+    defaultSort?: SortState | null;
+    /**
+     * Called with the new sort state whenever the user changes it, or `null` once sorting is cleared.
+     */
+    onSortChange?: (sort: SortState | null) => void;
+    /**
+     * Whether `data` already arrives sorted, so the table only renders sort indicators
+     * and header interactions without reordering rows itself. Use for server-side sorting.
+     * Defaults to false.
+     */
+    manualSort?: boolean;
+    /**
+     * Class applied to the sort indicator icon in a sortable column header.
+     */
+    sortIconClassName?: string;
 }


### PR DESCRIPTION
- [x] Add `sortable`, `sortAccessor` and `sortComparator` to column definitions.
- [x] Cycle sorting from an `aria-sort` header control, before pagination is applied.
- [x] Support controlled sorting through `sort`, `defaultSort` and `onSortChange`.
- [x] Add `manualSort` so server-ordered data is rendered untouched.
- [x] Sort hierarchical tables recursively, ordering siblings at every depth.