### PR TITLE
fix(popup): keep nested popups open and restore picker focus on close

### DIFF
--- a/__tests__/components/Inputs/PickerPopupBehavior.test.tsx
+++ b/__tests__/components/Inputs/PickerPopupBehavior.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, screen, fireEvent, cleanup, act, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DatePickerInput from '../../../components/Form/DatePickerInput';
+import DateTimePickerInput from '../../../components/Form/DateTimePickerInput';
+import useRect from '../../../hooks/useRect';
+
+// Popup is left unmocked: both defects need the calendar and its SelectInput on real portals.
+vi.mock('../../../hooks/useRect', () => ({
+    default: vi.fn(),
+}));
+
+vi.mock('react-focus-lock', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockUseRect = useRect as Mock;
+
+const getDatePopup = () => document.querySelector('.date-popup');
+const getDateTimePopup = () => document.querySelector('.date-time-popup');
+
+describe('Picker popup interaction', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockUseRect.mockReturnValue({
+            top: 100,
+            left: 200,
+            right: 400,
+            bottom: 150,
+            width: 200,
+            height: 50,
+        } as DOMRect);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('nested select inside the calendar popup', () => {
+        const renderWithMonthDropdown = () =>
+            render(
+                <DatePickerInput
+                    value="2024-01-15"
+                    onChange={onChange}
+                    calendarProps={{ enableMonthDropdown: true }}
+                />,
+            );
+
+        const openMonthOptions = () => {
+            const monthSelect = document.querySelector(
+                '.calendar-header-select',
+            ) as HTMLElement;
+            fireEvent.click(
+                monthSelect.querySelector('.select-control') as HTMLElement,
+            );
+            return monthSelect;
+        };
+
+        it('keeps the calendar open when a month option is picked', () => {
+            const { container } = renderWithMonthDropdown();
+
+            fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+            const monthSelect = openMonthOptions();
+
+            const marchOption = within(
+                document.querySelector('.select_options') as HTMLElement,
+            ).getByText('March');
+            fireEvent.mouseDown(marchOption);
+            fireEvent.click(marchOption);
+
+            expect(getDatePopup()).toBeInTheDocument();
+            expect(within(monthSelect).getByText('March')).toBeInTheDocument();
+        });
+
+        it('still closes the calendar when the click lands outside every popup', () => {
+            const { container } = renderWithMonthDropdown();
+
+            fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+            openMonthOptions();
+            fireEvent.mouseDown(document.body);
+
+            expect(getDatePopup()).not.toBeInTheDocument();
+        });
+    });
+
+    describe('focus handling on close', () => {
+        it('returns focus to the date input after a day is picked', () => {
+            const { container } = render(
+                <DatePickerInput value="2024-01-15" onChange={onChange} />,
+            );
+            const input = container.querySelector('input') as HTMLInputElement;
+
+            fireEvent.focus(input);
+            expect(getDatePopup()).toBeInTheDocument();
+
+            // Pressing a day moves focus off the input in a real browser.
+            expect(document.activeElement).not.toBe(input);
+            fireEvent.click(screen.getByText('20'));
+
+            expect(onChange).toHaveBeenCalledWith({
+                name: undefined,
+                value: '2024-01-20',
+            });
+            expect(document.activeElement).toBe(input);
+            expect(getDatePopup()).not.toBeInTheDocument();
+        });
+
+        it('returns focus to the date time input after a time is picked', () => {
+            const { container } = render(
+                <DateTimePickerInput
+                    value="2024-01-15T10:00"
+                    onChange={onChange}
+                    timeStepMinutes={60}
+                />,
+            );
+            const input = container.querySelector('input') as HTMLInputElement;
+
+            fireEvent.focus(input);
+            expect(getDateTimePopup()).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText('14:00'));
+
+            expect(document.activeElement).toBe(input);
+            expect(getDateTimePopup()).not.toBeInTheDocument();
+        });
+
+        it('leaves focus alone when an outside click closes the calendar', () => {
+            const { container } = render(
+                <>
+                    <DatePickerInput value="2024-01-15" onChange={onChange} />
+                    <button type="button" data-testid="other-control">
+                        Other
+                    </button>
+                </>,
+            );
+            const input = container.querySelector('input') as HTMLInputElement;
+            const otherControl = screen.getByTestId('other-control');
+
+            fireEvent.focus(input);
+            act(() => otherControl.focus());
+            fireEvent.mouseDown(otherControl);
+
+            expect(getDatePopup()).not.toBeInTheDocument();
+            expect(document.activeElement).toBe(otherControl);
+        });
+
+        it('reopens the calendar when the user focuses the input again', () => {
+            const { container } = render(
+                <DatePickerInput value="2024-01-15" onChange={onChange} />,
+            );
+            const input = container.querySelector('input') as HTMLInputElement;
+
+            fireEvent.focus(input);
+            fireEvent.click(screen.getByText('20'));
+            expect(getDatePopup()).not.toBeInTheDocument();
+
+            act(() => {
+                input.blur();
+                input.focus();
+            });
+
+            expect(getDatePopup()).toBeInTheDocument();
+        });
+    });
+});

--- a/__tests__/components/NestedPopup.test.tsx
+++ b/__tests__/components/NestedPopup.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRef } from 'react';
+
+import Popup from '../../components/Popup';
+import useRect from '../../hooks/useRect';
+
+vi.mock('../../hooks/useRect', () => ({
+    default: vi.fn(),
+}));
+
+vi.mock('react-focus-lock', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockUseRect = useRect as Mock;
+
+describe('Nested popups', () => {
+    const onOuterClose = vi.fn();
+    const onMiddleClose = vi.fn();
+    const onInnerClose = vi.fn();
+
+    const NestedPopups = ({ depth = 2 }: { depth?: number }) => {
+        const outerAnchorRef = useRef<HTMLButtonElement>(null);
+        const middleAnchorRef = useRef<HTMLButtonElement>(null);
+        const innerAnchorRef = useRef<HTMLButtonElement>(null);
+
+        return (
+            <>
+                <button ref={outerAnchorRef} data-testid="outer-anchor">
+                    Outer anchor
+                </button>
+                <Popup anchor={outerAnchorRef} onClose={onOuterClose}>
+                    <div data-testid="outer-content">
+                        <button ref={middleAnchorRef} data-testid="middle-anchor">
+                            Middle anchor
+                        </button>
+                        <Popup anchor={middleAnchorRef} onClose={onMiddleClose}>
+                            <div data-testid="middle-content">
+                                <button ref={innerAnchorRef} data-testid="inner-anchor">
+                                    Inner anchor
+                                </button>
+                                {depth > 2 && (
+                                    <Popup anchor={innerAnchorRef} onClose={onInnerClose}>
+                                        <div data-testid="inner-content">Inner content</div>
+                                    </Popup>
+                                )}
+                            </div>
+                        </Popup>
+                    </div>
+                </Popup>
+            </>
+        );
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockUseRect.mockReturnValue({
+            top: 100,
+            left: 200,
+            right: 400,
+            bottom: 150,
+            width: 200,
+            height: 50,
+        } as DOMRect);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('portals the nested popup outside the parent popup wrapper', () => {
+        render(<NestedPopups />);
+
+        const outerContent = screen.getByTestId('outer-content');
+        const middleContent = screen.getByTestId('middle-content');
+
+        expect(outerContent.parentElement?.parentElement).toBe(document.body);
+        expect(middleContent.parentElement?.parentElement).toBe(document.body);
+        expect(outerContent.contains(middleContent)).toBe(false);
+    });
+
+    it('keeps the parent popup open when the nested popup is clicked', () => {
+        render(<NestedPopups />);
+
+        fireEvent.mouseDown(screen.getByTestId('middle-content'));
+
+        expect(onOuterClose).not.toHaveBeenCalled();
+        expect(onMiddleClose).not.toHaveBeenCalled();
+    });
+
+    it('keeps every ancestor popup open when the deepest popup is clicked', () => {
+        render(<NestedPopups depth={3} />);
+
+        fireEvent.mouseDown(screen.getByTestId('inner-content'));
+
+        expect(onOuterClose).not.toHaveBeenCalled();
+        expect(onMiddleClose).not.toHaveBeenCalled();
+        expect(onInnerClose).not.toHaveBeenCalled();
+    });
+
+    it('still closes every popup on a genuine outside click', () => {
+        render(<NestedPopups depth={3} />);
+
+        fireEvent.mouseDown(document.body);
+
+        expect(onOuterClose).toHaveBeenCalledTimes(1);
+        expect(onMiddleClose).toHaveBeenCalledTimes(1);
+        expect(onInnerClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes only the parent popup when its own anchor region is left for an outside click', () => {
+        render(<NestedPopups />);
+
+        fireEvent.mouseDown(screen.getByTestId('outer-content'));
+
+        expect(onOuterClose).not.toHaveBeenCalled();
+        expect(onMiddleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the parent popup on an outside click after the nested popup unmounts', () => {
+        const { rerender } = render(<NestedPopups depth={3} />);
+
+        rerender(<NestedPopups depth={2} />);
+        fireEvent.mouseDown(document.body);
+
+        expect(onOuterClose).toHaveBeenCalledTimes(1);
+        expect(onMiddleClose).toHaveBeenCalledTimes(1);
+        expect(onInnerClose).not.toHaveBeenCalled();
+    });
+});

--- a/components/Calendar/usePickerDateField.tsx
+++ b/components/Calendar/usePickerDateField.tsx
@@ -94,11 +94,23 @@ export interface PickerDateField<Model> {
     warning: string | null;
     errorText: any;
     controlRef: React.RefObject<HTMLDivElement | null>;
+    inputRef: React.RefObject<HTMLInputElement | null>;
     Wrapper: React.ElementType;
     wrapperProps: { className?: string };
     showCalendar: () => void;
+    /**
+     * Closes the calendar and returns focus to the text input.
+     * Use for user-triggered closes from within the picker (selection, Enter, Escape) so focus never
+     * falls back to the document body, where an ancestor focus lock would recapture it.
+     */
     hideCalendar: () => void;
+    /**
+     * Closes the calendar without touching focus.
+     * Use for user-triggered closes from outside the picker, where the click target owns focus.
+     */
+    dismissCalendar: () => void;
     toggleCalendar: () => void;
+    handleInputFocus: () => void;
     handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
     commitTypedValue: () => "committed" | "reset";
@@ -173,6 +185,8 @@ const usePickerDateField = <Model,>(
     const [warning, setWarning] = useState<string | null>(null);
 
     const controlRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const restoringFocusRef = useRef(false);
 
     useEffect(() => {
         if (value !== undefined) {
@@ -198,12 +212,40 @@ const usePickerDateField = <Model,>(
         }
     }, [showRequired, required, selected]);
 
-    const hideCalendar = useCallback(() => setExpanded(false), []);
+    const dismissCalendar = useCallback(() => setExpanded(false), []);
+
+    // Flagged so the input's own focus handler can tell this apart from a user focus and not reopen.
+    const restoreInputFocus = useCallback(() => {
+        const input = inputRef.current;
+        if (disabled || !input || document.activeElement === input) {
+            return;
+        }
+        restoringFocusRef.current = true;
+        try {
+            input.focus();
+        } finally {
+            restoringFocusRef.current = false;
+        }
+    }, [disabled]);
+
+    const hideCalendar = useCallback(() => {
+        setExpanded(false);
+        restoreInputFocus();
+    }, [restoreInputFocus]);
+
     const showCalendar = useCallback(() => {
         if (!disabled) {
             setExpanded(true);
         }
     }, [disabled]);
+
+    const handleInputFocus = useCallback(() => {
+        if (restoringFocusRef.current) {
+            return;
+        }
+        showCalendar();
+    }, [showCalendar]);
+
     const toggleCalendar = useCallback(() => {
         setExpanded((previouslyExpanded) =>
             disabled ? previouslyExpanded : !previouslyExpanded,
@@ -477,11 +519,14 @@ const usePickerDateField = <Model,>(
         warning,
         errorText,
         controlRef,
+        inputRef,
         Wrapper,
         wrapperProps,
         showCalendar,
         hideCalendar,
+        dismissCalendar,
         toggleCalendar,
+        handleInputFocus,
         handleInputChange,
         handleKeyDown,
         commitTypedValue,

--- a/components/Form/DatePickerInput/index.tsx
+++ b/components/Form/DatePickerInput/index.tsx
@@ -161,6 +161,7 @@ const DatePickerInput: React.FC<DatePickerInputProps> = (props) => {
                     )}
                 >
                     <input
+                        ref={field.inputRef}
                         type="text"
                         className={cs(
                             styles.dateInput,
@@ -170,7 +171,7 @@ const DatePickerInput: React.FC<DatePickerInputProps> = (props) => {
                         value={field.inputText}
                         placeholder={placeholder}
                         disabled={disabled}
-                        onFocus={field.showCalendar}
+                        onFocus={field.handleInputFocus}
                         onChange={field.handleInputChange}
                         onBlur={field.commitTypedValue}
                         onKeyDown={field.handleKeyDown}
@@ -222,7 +223,7 @@ const DatePickerInput: React.FC<DatePickerInputProps> = (props) => {
                     anchor={field.controlRef}
                     anchorOrigin="bottom left"
                     transformOrigin="top left"
-                    onClose={field.hideCalendar}
+                    onClose={field.dismissCalendar}
                 >
                     <div className={styles.pickerPopup}>{field.calendar}</div>
                 </Popup>

--- a/components/Form/DateTimePickerInput/index.tsx
+++ b/components/Form/DateTimePickerInput/index.tsx
@@ -381,6 +381,7 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
                     )}
                 >
                     <input
+                        ref={field.inputRef}
                         type="text"
                         className={cs(
                             styles.dateTimeInput,
@@ -391,7 +392,7 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
                         value={field.inputText}
                         placeholder={placeholder}
                         disabled={disabled}
-                        onFocus={field.showCalendar}
+                        onFocus={field.handleInputFocus}
                         onChange={field.handleInputChange}
                         onBlur={field.commitTypedValue}
                         onKeyDown={field.handleKeyDown}
@@ -443,7 +444,7 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
                     anchor={field.controlRef}
                     anchorOrigin="bottom left"
                     transformOrigin="top left"
-                    onClose={field.hideCalendar}
+                    onClose={field.dismissCalendar}
                 >
                     <div className={styles.pickerPopup}>
                         <div

--- a/components/Popup/PopupNestingContext.ts
+++ b/components/Popup/PopupNestingContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+export type PopupContainsNode = (node: Node) => boolean;
+
+export interface PopupNestingContextValue {
+    /**
+     * Registers a descendant popup so the ancestor can treat clicks landing inside it as inside
+     * itself. Descendant popups portal outside the ancestor wrapper, so DOM containment alone
+     * cannot answer that question. Returns an unregister function.
+     */
+    registerNestedPopup: (containsNode: PopupContainsNode) => () => void;
+}
+
+const PopupNestingContext = createContext<PopupNestingContextValue | null>(null);
+
+export default PopupNestingContext;

--- a/components/Popup/index.tsx
+++ b/components/Popup/index.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useContext, useMemo, useState, useEffect, useRef } from 'react';
 import FocusLock from 'react-focus-lock';
 
 import styles from './styles.module.scss';
+import PopupNestingContext, {
+    type PopupContainsNode,
+    type PopupNestingContextValue,
+} from './PopupNestingContext';
 import type { PopupProps } from './types';
 import Portal from '../Portal';
 import withVisibleCheck from '../WithVisibleCheck';
@@ -19,6 +23,7 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
         className: _className,
         closeOnEscape = false,
         closeOnOutsideClick = true,
+        container,
         disableFocusLock = false,
         onClose = noop,
     } = props;
@@ -27,23 +32,58 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
     const [wrapperRect, setWrapperRect] = useState<React.CSSProperties>();
     const anchorRect = useRect(anchor.current);
 
+    const parentNesting = useContext(PopupNestingContext);
+    const nestedPopupsRef = useRef<Set<PopupContainsNode>>(new Set());
+
     const className = cs(styles.popup, 'popup', _className);
+
+    const containsNode = useCallback(
+        (node: Node) => {
+            if (wrapperRef.current?.contains(node) || anchor?.current?.contains(node)) {
+                return true;
+            }
+            for (const nestedContainsNode of nestedPopupsRef.current) {
+                if (nestedContainsNode(node)) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        [anchor],
+    );
+
+    const containsNodeRef = useRef(containsNode);
+    containsNodeRef.current = containsNode;
+
+    const reportContainsNode = useCallback((node: Node) => containsNodeRef.current(node), []);
+
+    const nestingContextValue = useMemo<PopupNestingContextValue>(
+        () => ({
+            registerNestedPopup: (nestedContainsNode) => {
+                nestedPopupsRef.current.add(nestedContainsNode);
+                return () => {
+                    nestedPopupsRef.current.delete(nestedContainsNode);
+                };
+            },
+        }),
+        [],
+    );
+
+    useEffect(
+        () => parentNesting?.registerNestedPopup(reportContainsNode),
+        [parentNesting, reportContainsNode],
+    );
 
     const handleClickOutside = useCallback(
         (event: MouseEvent) => {
             const { current: wrapper } = wrapperRef;
 
-            if (
-                closeOnOutsideClick &&
-                wrapper &&
-                !wrapper.contains(event.target as Node) &&
-                !anchor?.current?.contains(event.target as Node)
-            ) {
+            if (closeOnOutsideClick && wrapper && !containsNode(event.target as Node)) {
                 event.stopPropagation();
                 onClose(event);
             }
         },
-        [closeOnOutsideClick, onClose, anchor],
+        [closeOnOutsideClick, onClose, containsNode],
     );
 
     const handleKeyPressed = useCallback(
@@ -110,18 +150,23 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
     }, [anchorRect, transformWrapperRect]);
 
     return (
-        <Portal>
-            <FocusLock disabled={disableFocusLock} returnFocus>
-                {wrapperRect && (
-                    <div ref={wrapperRef} className={className} style={wrapperRect}>
-                        {children}
-                    </div>
-                )}
-            </FocusLock>
+        <Portal container={container}>
+            <PopupNestingContext.Provider value={nestingContextValue}>
+                <FocusLock disabled={disableFocusLock} returnFocus>
+                    {wrapperRect && (
+                        <div ref={wrapperRef} className={className} style={wrapperRect}>
+                            {children}
+                        </div>
+                    )}
+                </FocusLock>
+            </PopupNestingContext.Provider>
         </Portal>
     );
 }
 
 export default withVisibleCheck(Popup);
+
+export { default as PopupNestingContext } from './PopupNestingContext';
+export type { PopupContainsNode, PopupNestingContextValue } from './PopupNestingContext';
 
 export type { OriginPosition, PopupProps } from './types';

--- a/components/Popup/types.ts
+++ b/components/Popup/types.ts
@@ -45,6 +45,11 @@ export interface PopupProps<T extends HTMLElement | null> {
      */
     closeOnEscape?: boolean;
     /**
+     * DOM node the popup is portalled into
+     * Defaults to document.body
+     */
+    container?: Element | DocumentFragment;
+    /**
      * Disable focus capture
      */
     disableFocusLock?: boolean;


### PR DESCRIPTION
- [x] track descendant popups via context so a click inside one no longer closes ancestors.
- [x] treat a nested popup's anchor and descendants as inside on outside-click checks.
- [x] return focus to the picker input when the calendar closes from inside the picker.
- [x] guard the input focus handler so restored focus does not reopen the calendar.
- [x] add regression tests for nested popup clicks and picker focus restoration.