### PR TITLE
feat(calendar): add opt-in week start, outside days, and styling props

### DIFF
--- a/__tests__/components/Calendar.test.tsx
+++ b/__tests__/components/Calendar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import Calendar from '../../components/Calendar';
+import Calendar, { type CalendarProps } from '../../components/Calendar';
 import I18nProvider from '../../components/I18n';
 import styles from '../../components/Calendar/styles.module.scss';
 
@@ -25,7 +25,8 @@ describe('Calendar (nepali system)', () => {
         expect(screen.getByText('Sun')).toBeInTheDocument();
         expect(screen.getByText('Sat')).toBeInTheDocument();
         expect(container.querySelectorAll(`.${styles.day}`)).toHaveLength(31);
-        expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(6);
+        // Outside days render by default: 6 leading + 5 trailing pad the grid to full weeks.
+        expect(container.querySelectorAll(`.${styles.outsideDay}`)).toHaveLength(11);
     });
 
     it('marks the selected day and calls onChange with the clicked date', () => {
@@ -148,5 +149,202 @@ describe('Calendar (nepali system)', () => {
         expect(container.querySelectorAll('.my-day').length).toBeGreaterThan(0);
         expect(container.querySelector('.my-selected-day')).toHaveTextContent('15');
         expect(screen.getByText('15')).toHaveClass(styles.selected);
+    });
+});
+
+describe('Calendar (design props)', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    // Baishakh 2081 starts on a Saturday, so the default grid pads six leading cells.
+    const renderCalendar = (props: Partial<CalendarProps> = {}) =>
+        render(
+            <Calendar
+                system="nepali"
+                value={{ year: 2081, month: 1, day: 15 }}
+                onChange={onChange}
+                {...props}
+            />,
+        );
+
+    const weekdayLabels = (container: HTMLElement) =>
+        Array.from(container.querySelectorAll(`.${styles.weekday}`)).map(
+            (element) => element.textContent,
+        );
+
+    describe('weekStartsOn', () => {
+        it('starts the week on Sunday by default', () => {
+            const { container } = renderCalendar({ showOutsideDays: false });
+
+            expect(weekdayLabels(container)).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(6);
+        });
+
+        it('reorders the weekday labels and the leading offset together', () => {
+            const { container } = renderCalendar({ weekStartsOn: 1, showOutsideDays: false });
+
+            expect(weekdayLabels(container)).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+            // Saturday moves from index 6 to index 5, so one fewer leading cell.
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(5);
+            expect(container.querySelectorAll(`.${styles.day}`)).toHaveLength(31);
+        });
+
+        it('needs no leading cells when the month starts on the configured first day', () => {
+            const { container } = renderCalendar({ weekStartsOn: 6, showOutsideDays: false });
+
+            expect(weekdayLabels(container)[0]).toBe('Sat');
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(0);
+        });
+
+    });
+
+    describe('showOutsideDays', () => {
+        it('fills the leading and trailing cells with adjacent-month days by default', () => {
+            const { container } = renderCalendar();
+
+            const outsideDays = Array.from(
+                container.querySelectorAll(`.${styles.outsideDay}`),
+            ).map((element) => element.textContent);
+
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(0);
+            expect(container.querySelectorAll(`.${styles.day}`)).toHaveLength(31);
+            // Chaitra 2080 has 30 days, then Jestha 2081 pads the final week.
+            expect(outsideDays).toEqual([
+                '25', '26', '27', '28', '29', '30',
+                '1', '2', '3', '4', '5',
+            ]);
+            // Six complete rows of seven.
+            expect(container.querySelectorAll('.calendar-days > *')).toHaveLength(42);
+        });
+
+        it('renders blank padding cells and no adjacent-month days when disabled', () => {
+            const { container } = renderCalendar({ showOutsideDays: false });
+
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(6);
+            expect(container.querySelectorAll(`.${styles.outsideDay}`)).toHaveLength(0);
+            expect(container.querySelector('.calendar-outside-day')).not.toBeInTheDocument();
+        });
+
+        it('keeps outside days non-interactive and hidden from assistive technology', () => {
+            const { container } = renderCalendar();
+
+            const firstOutsideDay = container.querySelector(
+                `.${styles.outsideDay}`,
+            ) as HTMLElement;
+
+            // A disabled button rather than a div, so it matches the in-month cell metrics.
+            expect(firstOutsideDay.tagName).toBe('BUTTON');
+            expect(firstOutsideDay).toBeDisabled();
+            expect(firstOutsideDay).toHaveAttribute('tabindex', '-1');
+            expect(firstOutsideDay).toHaveAttribute('aria-hidden', 'true');
+
+            fireEvent.click(firstOutsideDay);
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it('pads the final week with blank cells past the maximum year', () => {
+            const { container } = render(
+                <Calendar
+                    system="gregorian"
+                    value={{ year: 2100, month: 12, day: 1 }}
+                    showOutsideDays
+                />,
+            );
+
+            // January 2101 is unsupported, so the trailing cell falls back to blank padding.
+            expect(container.querySelectorAll('.calendar-days > *')).toHaveLength(35);
+            expect(container.querySelectorAll(`.${styles.outsideDay}`)).toHaveLength(3);
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(1);
+        });
+
+        it('pads the first week with blank cells before the minimum year', () => {
+            const { container } = render(
+                <Calendar
+                    system="gregorian"
+                    value={{ year: 1900, month: 1, day: 1 }}
+                    showOutsideDays
+                />,
+            );
+
+            expect(container.querySelectorAll('.calendar-days > *')).toHaveLength(35);
+            expect(container.querySelectorAll(`.${styles.emptyDay}`)).toHaveLength(1);
+            expect(container.querySelectorAll(`.${styles.outsideDay}`)).toHaveLength(3);
+        });
+
+        it('reports outside days to renderDay so custom cells stay consistent', () => {
+            const renderDay = vi.fn(
+                (date, info) => `${date.month}/${date.day}${info.isOutsideMonth ? '*' : ''}`,
+            );
+            const { container } = renderCalendar({ showOutsideDays: true, renderDay });
+
+            expect(container.querySelector(`.${styles.outsideDay}`)).toHaveTextContent('12/25*');
+            expect(container.querySelector(`.${styles.day}`)).toHaveTextContent('1/1');
+            expect(renderDay).toHaveBeenCalledWith(
+                { year: 2081, month: 1, day: 15 },
+                expect.objectContaining({ isSelected: true, isOutsideMonth: false }),
+            );
+        });
+    });
+
+    describe('hideYearNavigation', () => {
+        it('renders both year steppers by default', () => {
+            const { container } = renderCalendar();
+
+            expect(container.querySelectorAll('.calendar-nav-button')).toHaveLength(4);
+            expect(screen.getByLabelText('Previous year')).toBeInTheDocument();
+            expect(screen.getByLabelText('Next year')).toBeInTheDocument();
+        });
+
+        it('drops the year steppers but keeps the month steppers when enabled', () => {
+            const { container } = renderCalendar({ hideYearNavigation: true });
+
+            expect(container.querySelectorAll('.calendar-nav-button')).toHaveLength(2);
+            expect(screen.queryByLabelText('Previous year')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Next year')).not.toBeInTheDocument();
+
+            fireEvent.click(screen.getByLabelText('Next month'));
+            expect(screen.getByText('Jestha')).toBeInTheDocument();
+        });
+    });
+
+    describe('classNames styling hooks', () => {
+        it('adds no classes for the parts a consumer leaves out', () => {
+            const { container } = renderCalendar({
+                minimumDate: { year: 2081, month: 1, day: 10 },
+            });
+
+            const navigationButtons = container.querySelectorAll('.calendar-nav-button');
+            expect(navigationButtons[0].className).toBe(
+                `${styles.navigationButton} calendar-nav-button`,
+            );
+            expect(screen.getByText('9')).toBeDisabled();
+            expect(screen.getByText('9').className).toBe(`${styles.day} calendar-day`);
+        });
+
+        it('targets each stepper, the disabled days, and the outside days', () => {
+            const { container } = renderCalendar({
+                showOutsideDays: true,
+                minimumDate: { year: 2081, month: 1, day: 10 },
+                classNames: {
+                    previousYearButton: 'my-prev-year',
+                    previousMonthButton: 'my-prev-month',
+                    nextMonthButton: 'my-next-month',
+                    nextYearButton: 'my-next-year',
+                    disabledDay: 'my-disabled-day',
+                    outsideDay: 'my-outside-day',
+                },
+            });
+
+            expect(screen.getByLabelText('Previous year')).toHaveClass('my-prev-year');
+            expect(screen.getByLabelText('Previous month')).toHaveClass('my-prev-month');
+            expect(screen.getByLabelText('Next month')).toHaveClass('my-next-month');
+            expect(screen.getByLabelText('Next year')).toHaveClass('my-next-year');
+            // Days 1 to 9 fall before the minimum date.
+            expect(container.querySelectorAll('.my-disabled-day')).toHaveLength(9);
+            expect(container.querySelectorAll('.my-outside-day')).toHaveLength(11);
+        });
     });
 });

--- a/__tests__/components/Inputs/DatePickerInput.test.tsx
+++ b/__tests__/components/Inputs/DatePickerInput.test.tsx
@@ -265,4 +265,52 @@ describe('DatePickerInput customization hooks', () => {
         expect(screen.getByTestId('day-20')).toHaveAttribute('data-disabled', 'true');
         expect(screen.getByTestId('day-19')).toHaveAttribute('data-disabled', 'false');
     });
+
+    it('shows the default calendar layout when no calendarProps are passed', () => {
+        const { container } = render(
+            <DatePickerInput value="2024-01-15" onChange={onChange} />,
+        );
+
+        fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+
+        expect(container.querySelectorAll('.calendar-nav-button')).toHaveLength(4);
+        // Outside days render by default; a consumer opts out with `showOutsideDays: false`.
+        expect(container.querySelector('.calendar-outside-day')).toBeInTheDocument();
+        expect(container.querySelectorAll('.calendar-weekday')[0]).toHaveTextContent('Sun');
+    });
+
+    it('hides adjacent-month days when calendarProps opts out of showOutsideDays', () => {
+        const { container } = render(
+            <DatePickerInput
+                value="2024-01-15"
+                calendarProps={{ showOutsideDays: false }}
+                onChange={onChange}
+            />,
+        );
+
+        fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+
+        expect(container.querySelector('.calendar-outside-day')).not.toBeInTheDocument();
+    });
+
+    it('forwards the calendar design props through calendarProps', () => {
+        const { container } = render(
+            <DatePickerInput
+                value="2024-01-15"
+                calendarProps={{
+                    weekStartsOn: 1,
+                    showOutsideDays: true,
+                    hideYearNavigation: true,
+                    classNames: { outsideDay: 'my-outside-day' },
+                }}
+                onChange={onChange}
+            />,
+        );
+
+        fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+
+        expect(container.querySelectorAll('.calendar-nav-button')).toHaveLength(2);
+        expect(container.querySelectorAll('.calendar-weekday')[0]).toHaveTextContent('Mon');
+        expect(container.querySelectorAll('.my-outside-day').length).toBeGreaterThan(0);
+    });
 });

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -14,6 +14,7 @@ import type {
     CalendarDayInfo,
     CalendarProps,
     CalendarSystem,
+    CalendarWeekday,
 } from "./types";
 import SelectInput from "../Form/SelectInput";
 import { useI18nContext } from "../I18n";
@@ -44,7 +45,7 @@ import List, {
     ListRenderItemProps,
 } from "../List";
 
-const WEEKDAY_INDICES = [0, 1, 2, 3, 4, 5, 6];
+const DAYS_IN_WEEK = 7;
 
 const MINIMUM_GREGORIAN_YEAR = 1900;
 const MAXIMUM_GREGORIAN_YEAR = 2100;
@@ -99,8 +100,55 @@ const navigationOptionKeyExtractor = (option: NavigationOption) => option.value;
 const navigationOptionValueExtractor = (option: NavigationOption) =>
     option.label;
 
-const dayKeyExtractor: KeyExtractor<number | null> = (item, index) =>
-    item === null ? `empty-${index}` : String(item);
+type CalendarCell =
+    | { type: "empty" }
+    | { type: "day"; day: number }
+    | { type: "outside"; year: number; month: number; day: number };
+
+const dayKeyExtractor: KeyExtractor<CalendarCell> = (item, index) => {
+    if (item.type === "empty") {
+        return `empty-${index}`;
+    }
+    if (item.type === "outside") {
+        return `outside-${item.year}-${item.month}-${item.day}`;
+    }
+    return String(item.day);
+};
+
+interface AdjacentMonth {
+    year: number;
+    month: number;
+    daysInMonth: number;
+}
+
+// Returns null past the date system's supported years, where day counts are unavailable.
+const getAdjacentMonth = (
+    dateSystem: CalendarDateSystem,
+    year: number,
+    month: number,
+    offset: -1 | 1,
+): AdjacentMonth | null => {
+    let targetYear = year;
+    let targetMonth = month + offset;
+    if (targetMonth < 1) {
+        targetYear -= 1;
+        targetMonth = 12;
+    } else if (targetMonth > 12) {
+        targetYear += 1;
+        targetMonth = 1;
+    }
+    if (
+        targetYear < dateSystem.minimumYear ||
+        targetYear > dateSystem.maximumYear
+    ) {
+        return null;
+    }
+    return {
+        year: targetYear,
+        month: targetMonth,
+        daysInMonth: dateSystem.getDaysInMonth(targetYear, targetMonth),
+    };
+};
 
 const Calendar: React.FC<CalendarProps> = (props) => {
     const {
@@ -115,6 +163,9 @@ const Calendar: React.FC<CalendarProps> = (props) => {
         language: languageProp,
         enableYearDropdown = false,
         enableMonthDropdown = false,
+        weekStartsOn = 0,
+        showOutsideDays = true,
+        hideYearNavigation = false,
         isDateDisabled,
         renderDay,
     } = props;
@@ -219,7 +270,17 @@ const Calendar: React.FC<CalendarProps> = (props) => {
     const canShowPreviousYear = visibleYear > minimumBound.year;
     const canShowNextYear = visibleYear < maximumBound.year;
 
-    const dayCells = useMemo(() => {
+    const weekdayIndices = useMemo<CalendarWeekday[]>(
+        () =>
+            Array.from(
+                { length: DAYS_IN_WEEK },
+                (_, index) =>
+                    ((weekStartsOn + index) % DAYS_IN_WEEK) as CalendarWeekday,
+            ),
+        [weekStartsOn],
+    );
+
+    const dayCells = useMemo<CalendarCell[]>(() => {
         const firstWeekdayIndex = dateSystem.firstWeekdayIndex(
             visibleYear,
             visibleMonth,
@@ -228,20 +289,66 @@ const Calendar: React.FC<CalendarProps> = (props) => {
             visibleYear,
             visibleMonth,
         );
-        const leadingCells: null[] = Array.from(
-            { length: firstWeekdayIndex },
-            () => null,
-        );
-        const dayNumbers = Array.from(
+        const leadingCount =
+            (firstWeekdayIndex - weekStartsOn + DAYS_IN_WEEK) % DAYS_IN_WEEK;
+        const monthCells: CalendarCell[] = Array.from(
             { length: daysInMonth },
-            (_, index) => index + 1,
+            (_, index) => ({ type: "day", day: index + 1 }),
         );
-        return [...leadingCells, ...dayNumbers];
-    }, [dateSystem, visibleYear, visibleMonth]);
+
+        if (!showOutsideDays) {
+            const emptyCells: CalendarCell[] = Array.from(
+                { length: leadingCount },
+                () => ({ type: "empty" }),
+            );
+            return [...emptyCells, ...monthCells];
+        }
+
+        const previousMonth = getAdjacentMonth(
+            dateSystem,
+            visibleYear,
+            visibleMonth,
+            -1,
+        );
+        const firstLeadingDay = previousMonth
+            ? previousMonth.daysInMonth - leadingCount + 1
+            : 0;
+        const leadingCells: CalendarCell[] = previousMonth
+            ? Array.from({ length: leadingCount }, (_, index) => ({
+                  type: "outside" as const,
+                  year: previousMonth.year,
+                  month: previousMonth.month,
+                  day: firstLeadingDay + index,
+              }))
+            : Array.from({ length: leadingCount }, () => ({
+                  type: "empty" as const,
+              }));
+
+        const nextMonth = getAdjacentMonth(
+            dateSystem,
+            visibleYear,
+            visibleMonth,
+            1,
+        );
+        const trailingCount =
+            (DAYS_IN_WEEK - ((leadingCount + daysInMonth) % DAYS_IN_WEEK)) %
+            DAYS_IN_WEEK;
+        const trailingCells: CalendarCell[] = nextMonth
+            ? Array.from({ length: trailingCount }, (_, index) => ({
+                  type: "outside" as const,
+                  year: nextMonth.year,
+                  month: nextMonth.month,
+                  day: index + 1,
+              }))
+            : Array.from({ length: trailingCount }, () => ({
+                  type: "empty" as const,
+              }));
+
+        return [...leadingCells, ...monthCells, ...trailingCells];
+    }, [dateSystem, visibleYear, visibleMonth, weekStartsOn, showOutsideDays]);
 
     const isDayDisabled = useCallback(
-        (day: number) => {
-            const date = { year: visibleYear, month: visibleMonth, day };
+        (date: CalendarDate) => {
             if (
                 dateSystem.compare(date, minimumBound) < 0 ||
                 dateSystem.compare(date, maximumBound) > 0
@@ -250,22 +357,16 @@ const Calendar: React.FC<CalendarProps> = (props) => {
             }
             return isDateDisabled ? isDateDisabled(date) : false;
         },
-        [
-            dateSystem,
-            visibleYear,
-            visibleMonth,
-            minimumBound,
-            maximumBound,
-            isDateDisabled,
-        ],
+        [dateSystem, minimumBound, maximumBound, isDateDisabled],
     );
 
     const handleDayClick = useCallback(
         (day: number) => {
-            if (isDayDisabled(day)) {
+            const date = { year: visibleYear, month: visibleMonth, day };
+            if (isDayDisabled(date)) {
                 return;
             }
-            onChange?.({ year: visibleYear, month: visibleMonth, day });
+            onChange?.(date);
         },
         [onChange, visibleYear, visibleMonth, isDayDisabled],
     );
@@ -334,7 +435,7 @@ const Calendar: React.FC<CalendarProps> = (props) => {
         [navigateToMonth, visibleMonth, visibleYear],
     );
 
-    const renderDayCell: ListRenderItem<number | null> = useCallback(
+    const renderDayCell: ListRenderItem<CalendarCell> = useCallback(
         (listProps) => {
             return (
                 <DayCellItem
@@ -383,25 +484,29 @@ const Calendar: React.FC<CalendarProps> = (props) => {
                     classNames?.header,
                 )}
             >
+                {!hideYearNavigation && (
+                    <button
+                        type="button"
+                        className={cs(
+                            styles.navigationButton,
+                            "calendar-nav-button",
+                            classNames?.navigationButton,
+                            classNames?.previousYearButton,
+                        )}
+                        aria-label="Previous year"
+                        disabled={!canShowPreviousYear}
+                        onClick={handleGoToPreviousYear}
+                    >
+                        <FiChevronsLeft />
+                    </button>
+                )}
                 <button
                     type="button"
                     className={cs(
                         styles.navigationButton,
                         "calendar-nav-button",
                         classNames?.navigationButton,
-                    )}
-                    aria-label="Previous year"
-                    disabled={!canShowPreviousYear}
-                    onClick={handleGoToPreviousYear}
-                >
-                    <FiChevronsLeft />
-                </button>
-                <button
-                    type="button"
-                    className={cs(
-                        styles.navigationButton,
-                        "calendar-nav-button",
-                        classNames?.navigationButton,
+                        classNames?.previousMonthButton,
                     )}
                     aria-label="Previous month"
                     disabled={!canShowPreviousMonth}
@@ -474,6 +579,7 @@ const Calendar: React.FC<CalendarProps> = (props) => {
                         styles.navigationButton,
                         "calendar-nav-button",
                         classNames?.navigationButton,
+                        classNames?.nextMonthButton,
                     )}
                     aria-label="Next month"
                     disabled={!canShowNextMonth}
@@ -481,19 +587,22 @@ const Calendar: React.FC<CalendarProps> = (props) => {
                 >
                     <FiChevronRight />
                 </button>
-                <button
-                    type="button"
-                    className={cs(
-                        styles.navigationButton,
-                        "calendar-nav-button",
-                        classNames?.navigationButton,
-                    )}
-                    aria-label="Next year"
-                    disabled={!canShowNextYear}
-                    onClick={handleGoToNextYear}
-                >
-                    <FiChevronsRight />
-                </button>
+                {!hideYearNavigation && (
+                    <button
+                        type="button"
+                        className={cs(
+                            styles.navigationButton,
+                            "calendar-nav-button",
+                            classNames?.navigationButton,
+                            classNames?.nextYearButton,
+                        )}
+                        aria-label="Next year"
+                        disabled={!canShowNextYear}
+                        onClick={handleGoToNextYear}
+                    >
+                        <FiChevronsRight />
+                    </button>
+                )}
             </div>
             <div
                 className={cs(
@@ -502,7 +611,7 @@ const Calendar: React.FC<CalendarProps> = (props) => {
                     classNames?.weekdays,
                 )}
             >
-                {WEEKDAY_INDICES.map((weekdayIndex) => (
+                {weekdayIndices.map((weekdayIndex) => (
                     <div
                         key={weekdayIndex}
                         className={cs(
@@ -526,14 +635,14 @@ const Calendar: React.FC<CalendarProps> = (props) => {
 };
 
 function DayCellItem(
-    props: ListRenderItemProps<number | null> & {
+    props: ListRenderItemProps<CalendarCell> & {
         classNames: CalendarProps["classNames"];
         visibleYear: number;
         visibleMonth: number;
         dateSystem: CalendarDateSystem;
         today: CalendarDate;
         value: CalendarProps["value"];
-        isDayDisabled: (day: number) => boolean;
+        isDayDisabled: (date: CalendarDate) => boolean;
         onDayClick: (day: number) => void;
         formatNumberLabel: (arg: number) => string;
         renderDay?: (date: CalendarDate, info: CalendarDayInfo) => React.ReactNode;
@@ -554,12 +663,12 @@ function DayCellItem(
     } = props;
 
     const handleDayClick = useCallback(() => {
-        if (item !== null) {
-            onDayClick(item);
+        if (item.type === "day") {
+            onDayClick(item.day);
         }
     }, [item, onDayClick]);
 
-    if (item === null) {
+    if (item.type === "empty") {
         return (
             <div
                 className={cs(
@@ -570,12 +679,45 @@ function DayCellItem(
             />
         );
     }
-    const date = { year: visibleYear, month: visibleMonth, day: item };
+
+    const date =
+        item.type === "outside"
+            ? { year: item.year, month: item.month, day: item.day }
+            : { year: visibleYear, month: visibleMonth, day: item.day };
     const isSelected =
         dateSystem.isValid(value) &&
         dateSystem.compare(date, value as CalendarDate) === 0;
     const isToday = dateSystem.compare(date, today) === 0;
-    const disabled = isDayDisabled(item);
+    const disabled = isDayDisabled(date);
+    const dayInfo: CalendarDayInfo = {
+        isSelected,
+        isDisabled: disabled,
+        isToday,
+        isOutsideMonth: item.type === "outside",
+    };
+    const label = renderDay
+        ? renderDay(date, dayInfo)
+        : formatNumberLabel(item.day);
+
+    // A disabled button, not a div, so the cell shares the in-month day's font metrics.
+    if (item.type === "outside") {
+        return (
+            <button
+                type="button"
+                className={cs(
+                    styles.outsideDay,
+                    "calendar-outside-day",
+                    classNames?.outsideDay,
+                )}
+                disabled
+                tabIndex={-1}
+                aria-hidden="true"
+            >
+                {label}
+            </button>
+        );
+    }
+
     return (
         <button
             type="button"
@@ -591,13 +733,12 @@ function DayCellItem(
                 isSelected && classNames?.selectedDay,
                 isToday && "calendar-day-today",
                 isToday && classNames?.today,
+                disabled && classNames?.disabledDay,
             )}
             disabled={disabled}
             onClick={handleDayClick}
         >
-            {renderDay
-                ? renderDay(date, { isSelected, isDisabled: disabled, isToday })
-                : formatNumberLabel(item)}
+            {label}
         </button>
     );
 }

--- a/components/Calendar/styles.module.scss
+++ b/components/Calendar/styles.module.scss
@@ -93,5 +93,15 @@
                 cursor: default;
             }
         }
+
+        .outsideDay {
+            padding: 0.4em 0;
+            border: none;
+            background: none;
+            cursor: default;
+            text-align: center;
+            color: var(--calendar-outside-text-color, var(--color-text-light));
+            opacity: 0.65;
+        }
     }
 }

--- a/components/Calendar/types.ts
+++ b/components/Calendar/types.ts
@@ -2,6 +2,11 @@ import type { ReactNode } from 'react';
 
 export type CalendarSystem = 'gregorian' | 'nepali';
 
+/**
+ * Day-of-week index, `0` for Sunday through `6` for Saturday.
+ */
+export type CalendarWeekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
 export interface CalendarDate {
     year: number;
     month: number;
@@ -15,8 +20,18 @@ export interface CalendarViewDate {
 
 export interface CalendarDayInfo {
     isSelected: boolean;
+    /**
+     * Reflects only the date-bounds check (`minDate`/`maxDate`). Outside-month
+     * cells are always rendered non-interactive regardless of this value; use
+     * `isOutsideMonth` to identify those cells.
+     */
     isDisabled: boolean;
     isToday: boolean;
+    /**
+     * `true` when the cell belongs to an adjacent month, which only happens
+     * while `showOutsideDays` is enabled. Always `false` otherwise.
+     */
+    isOutsideMonth: boolean;
 }
 
 export interface CalendarDateSystem {
@@ -32,20 +47,51 @@ export interface CalendarDateSystem {
     numberLabel: (value: number, language?: string) => string;
 }
 
+/**
+ * Class names for the calendar's internal parts, so a consumer can restyle any
+ * piece without forking the component. Every entry is optional and additive:
+ * an omitted key contributes no class at all.
+ */
 export interface CalendarClassNames {
+    /** Outermost calendar element. */
     root?: string;
+    /** Header row holding the navigation buttons and the month/year title. */
     header?: string;
+    /** Every month and year stepper button. */
     navigationButton?: string;
+    /** Only the previous-year stepper, applied after `navigationButton`. */
+    previousYearButton?: string;
+    /** Only the previous-month stepper, applied after `navigationButton`. */
+    previousMonthButton?: string;
+    /** Only the next-month stepper, applied after `navigationButton`. */
+    nextMonthButton?: string;
+    /** Only the next-year stepper, applied after `navigationButton`. */
+    nextYearButton?: string;
+    /** Wrapper around the month and year labels or dropdowns. */
     title?: string;
+    /** Month label, when `enableMonthDropdown` is off. */
     titleMonth?: string;
+    /** Year label, when `enableYearDropdown` is off. */
     titleYear?: string;
+    /** Month and year dropdowns, when they are enabled. */
     headerSelect?: string;
+    /** Weekday label row. */
     weekdays?: string;
+    /** Each weekday label cell. */
     weekday?: string;
+    /** The day grid. */
     days?: string;
+    /** Every day cell of the visible month. */
     day?: string;
+    /** The day cell matching `value`. */
     selectedDay?: string;
+    /** The day cell matching today's date. */
     today?: string;
+    /** Day cells that are out of bounds or rejected by `isDateDisabled`. */
+    disabledDay?: string;
+    /** Adjacent-month day cells rendered by `showOutsideDays`. */
+    outsideDay?: string;
+    /** Placeholder cells that pad the first week when `showOutsideDays` is off. */
     emptyDay?: string;
 }
 
@@ -61,6 +107,29 @@ export interface CalendarProps {
     language?: string;
     enableYearDropdown?: boolean;
     enableMonthDropdown?: boolean;
+    /**
+     * Day of the week the grid starts on, `0` for Sunday through `6` for Saturday.
+     * Reorders the weekday labels and the leading offset together.
+     *
+     * @default 0
+     */
+    weekStartsOn?: CalendarWeekday;
+    /**
+     * Render the leading and trailing days of the adjacent months instead of blank
+     * padding cells, and pad the final week so every row is complete. Outside days
+     * are de-emphasized and non-interactive; they are hidden from assistive
+     * technology and cannot be selected.
+     *
+     * @default true
+     */
+    showOutsideDays?: boolean;
+    /**
+     * Hide the year stepper buttons on both sides of the header, leaving only the
+     * month steppers. Year navigation stays reachable through `enableYearDropdown`.
+     *
+     * @default false
+     */
+    hideYearNavigation?: boolean;
     isDateDisabled?: (date: CalendarDate) => boolean;
     renderDay?: (date: CalendarDate, info: CalendarDayInfo) => ReactNode;
 }


### PR DESCRIPTION
- [x] Add `weekStartsOn` to configure the first day of the calendar grid.
- [x] Add `showOutsideDays` for adjacent-month day padding, enabled by default.
- [x] Add `hideYearNavigation` to drop the year stepper buttons.
- [x] Expose per-stepper, disabled-day, and outside-day `classNames` hooks.
- [x] Cover each new prop on and off; only `showOutsideDays` changes default markup.