### PR TITLE
fix(datepicker): convert visible window on AD/BS toggle

### DIFF
--- a/__tests__/components/Calendar.test.tsx
+++ b/__tests__/components/Calendar.test.tsx
@@ -5,6 +5,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Calendar, { type CalendarProps } from '../../components/Calendar';
 import I18nProvider from '../../components/I18n';
 import styles from '../../components/Calendar/styles.module.scss';
+import {
+    MAXIMUM_BIKRAM_SAMBAT_YEAR,
+    MINIMUM_BIKRAM_SAMBAT_YEAR,
+    convertBikramSambatToGregorian,
+    convertGregorianToBikramSambat,
+    getBikramSambatMonthLabel,
+    getGregorianMonthLabel,
+    jsDateToGregorian,
+} from '../../utils/date';
 
 describe('Calendar (nepali system)', () => {
     const onChange = vi.fn();
@@ -346,5 +355,368 @@ describe('Calendar (design props)', () => {
             expect(container.querySelectorAll('.my-disabled-day')).toHaveLength(9);
             expect(container.querySelectorAll('.my-outside-day')).toHaveLength(11);
         });
+    });
+});
+
+describe('Calendar (AD/BS system toggle)', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('converts the visible window from AD to BS when no date is selected', () => {
+        const adWindow = { year: 2026, month: 8, day: 1 };
+        const bsWindow = convertGregorianToBikramSambat(
+            new Date(adWindow.year, adWindow.month - 1, adWindow.day),
+        );
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+        );
+        expect(screen.getByText(getGregorianMonthLabel(adWindow.month))).toBeInTheDocument();
+        expect(screen.getByText(String(adWindow.year))).toBeInTheDocument();
+
+        rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(bsWindow.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(bsWindow.year),
+        );
+    });
+
+    it('returns to the original AD window after an AD -> BS -> AD round trip', () => {
+        const adWindow = { year: 2026, month: 8, day: 1 };
+        const bsWindow = convertGregorianToBikramSambat(
+            new Date(adWindow.year, adWindow.month - 1, adWindow.day),
+        );
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+        );
+
+        rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(bsWindow.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(bsWindow.year),
+        );
+
+        rerender(<Calendar system="gregorian" value={null} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getGregorianMonthLabel(adWindow.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(adWindow.year),
+        );
+    });
+
+    it('keeps the visible window stable across repeated AD/BS toggles', () => {
+        const adWindow = { year: 2026, month: 8, day: 1 };
+        const bsWindow = convertGregorianToBikramSambat(
+            new Date(adWindow.year, adWindow.month - 1, adWindow.day),
+        );
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+        );
+
+        for (let round = 0; round < 4; round += 1) {
+            rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+            expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                getBikramSambatMonthLabel(bsWindow.month),
+            );
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                String(bsWindow.year),
+            );
+
+            rerender(<Calendar system="gregorian" value={null} onChange={onChange} />);
+            expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                getGregorianMonthLabel(adWindow.month),
+            );
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                String(adWindow.year),
+            );
+        }
+    });
+
+    it('returns to the original BS window after a BS -> AD -> BS round trip', () => {
+        const bsWindow = { year: 2083, month: 4, day: 1 };
+        const adWindow = jsDateToGregorian(convertBikramSambatToGregorian(bsWindow));
+
+        const { rerender, container } = render(
+            <Calendar system="nepali" value={null} viewDate={bsWindow} onChange={onChange} />,
+        );
+
+        rerender(<Calendar system="gregorian" value={null} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(adWindow.year),
+        );
+
+        rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(bsWindow.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(bsWindow.year),
+        );
+    });
+
+    it('converts the visible window from BS to AD when no date is selected', () => {
+        const bsWindow = { year: 2083, month: 4, day: 1 };
+        const adWindow = jsDateToGregorian(convertBikramSambatToGregorian(bsWindow));
+
+        const { rerender, container } = render(
+            <Calendar system="nepali" value={null} viewDate={bsWindow} onChange={onChange} />,
+        );
+        expect(screen.getByText(getBikramSambatMonthLabel(bsWindow.month))).toBeInTheDocument();
+        expect(screen.getByText(String(bsWindow.year))).toBeInTheDocument();
+
+        rerender(<Calendar system="gregorian" value={null} onChange={onChange} />);
+
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getGregorianMonthLabel(adWindow.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(adWindow.year),
+        );
+    });
+
+    it('clamps to the BS minimum year instead of throwing when the AD window is below it', () => {
+        const adWindow = { year: 1905, month: 6, day: 1 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+        );
+        expect(screen.getByText(String(adWindow.year))).toBeInTheDocument();
+
+        expect(() => {
+            rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+        }).not.toThrow();
+
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(MINIMUM_BIKRAM_SAMBAT_YEAR),
+        );
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(1),
+        );
+    });
+
+    it('clamps to the BS maximum year instead of throwing when the AD window is above it', () => {
+        const adWindow = { year: 2090, month: 3, day: 1 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+        );
+        expect(screen.getByText(String(adWindow.year))).toBeInTheDocument();
+
+        expect(() => {
+            rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+        }).not.toThrow();
+
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+        );
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(12),
+        );
+    });
+
+    it('still tracks a selected date across an AD/BS toggle', () => {
+        const adDate = { year: 2026, month: 8, day: 15 };
+        const bsDate = convertGregorianToBikramSambat(
+            new Date(adDate.year, adDate.month - 1, adDate.day),
+        );
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={adDate} onChange={onChange} />,
+        );
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent(
+            String(adDate.day),
+        );
+
+        rerender(<Calendar system="nepali" value={bsDate} onChange={onChange} />);
+
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(bsDate.month),
+        );
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent(
+            String(bsDate.day),
+        );
+    });
+});
+
+// BS covers AD 1918-04-13 through AD 2044-04-12; AD dates outside that span have no BS counterpart.
+describe('Calendar (AD/BS toggle with a selection outside the BS range)', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('clamps the window to the BS maximum and leaves the AD value untouched', () => {
+        const adDate = { year: 2050, month: 6, day: 15 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={adDate} onChange={onChange} />,
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2050');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('15');
+
+        // The consumer has no BS date to hand over, so the BS leg opens with nothing selected.
+        expect(() => {
+            rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+        }).not.toThrow();
+
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+        );
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(12),
+        );
+        // An unrepresentable date must not ghost onto a day of the clamped window.
+        expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+        rerender(<Calendar system="gregorian" value={adDate} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getGregorianMonthLabel(adDate.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2050');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('15');
+        expect(adDate).toEqual({ year: 2050, month: 6, day: 15 });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('clamps the window to the BS minimum and leaves the AD value untouched', () => {
+        // 1910 falls outside the BS year range, so the same object reads as no selection in BS.
+        const adDate = { year: 1910, month: 3, day: 1 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={adDate} onChange={onChange} />,
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('1910');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('1');
+
+        expect(() => {
+            rerender(<Calendar system="nepali" value={adDate} onChange={onChange} />);
+        }).not.toThrow();
+
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+            String(MINIMUM_BIKRAM_SAMBAT_YEAR),
+        );
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(1),
+        );
+        expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+        rerender(<Calendar system="gregorian" value={adDate} onChange={onChange} />);
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getGregorianMonthLabel(adDate.month),
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('1910');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('1');
+        expect(adDate).toEqual({ year: 1910, month: 3, day: 1 });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('keeps the value and the AD window exact across repeated clamped toggles', () => {
+        const adDate = { year: 2050, month: 6, day: 15 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={adDate} onChange={onChange} />,
+        );
+
+        for (let round = 0; round < 4; round += 1) {
+            rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+            );
+            expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+            rerender(<Calendar system="gregorian" value={adDate} onChange={onChange} />);
+            expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                getGregorianMonthLabel(adDate.month),
+            );
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2050');
+            expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('15');
+        }
+
+        expect(adDate).toEqual({ year: 2050, month: 6, day: 15 });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('returns to the exact AD window after repeated clamped toggles at either bound', () => {
+        const bounds = [
+            { adWindow: { year: 2090, month: 3, day: 1 }, bsYear: MAXIMUM_BIKRAM_SAMBAT_YEAR, bsMonth: 12 },
+            { adWindow: { year: 1905, month: 6, day: 1 }, bsYear: MINIMUM_BIKRAM_SAMBAT_YEAR, bsMonth: 1 },
+        ];
+
+        bounds.forEach(({ adWindow, bsYear, bsMonth }) => {
+            const { rerender, container, unmount } = render(
+                <Calendar system="gregorian" value={null} viewDate={adWindow} onChange={onChange} />,
+            );
+
+            for (let round = 0; round < 4; round += 1) {
+                rerender(<Calendar system="nepali" value={null} onChange={onChange} />);
+                expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                    String(bsYear),
+                );
+                expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                    getBikramSambatMonthLabel(bsMonth),
+                );
+
+                // The clamp lands on the window only; the anchor still holds the chosen AD month.
+                rerender(<Calendar system="gregorian" value={null} onChange={onChange} />);
+                expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                    getGregorianMonthLabel(adWindow.month),
+                );
+                expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                    String(adWindow.year),
+                );
+            }
+
+            unmount();
+        });
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});
+
+describe('Calendar (AD/BS toggle with a viewDate held across the system change)', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    // Only the round trip is pinned: an untagged viewDate held across the change still steers the BS leg.
+    it('returns to the exact AD window across repeated toggles', () => {
+        const viewDate = { year: 2090, month: 3 };
+
+        const { rerender, container } = render(
+            <Calendar system="gregorian" value={null} viewDate={viewDate} onChange={onChange} />,
+        );
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2090');
+
+        for (let round = 0; round < 3; round += 1) {
+            expect(() => {
+                rerender(
+                    <Calendar system="nepali" value={null} viewDate={viewDate} onChange={onChange} />,
+                );
+            }).not.toThrow();
+
+            rerender(
+                <Calendar system="gregorian" value={null} viewDate={viewDate} onChange={onChange} />,
+            );
+            expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                getGregorianMonthLabel(3),
+            );
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2090');
+        }
+
+        expect(onChange).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/components/Inputs/DatePickerInput.test.tsx
+++ b/__tests__/components/Inputs/DatePickerInput.test.tsx
@@ -3,6 +3,12 @@ import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DatePickerInput from '../../../components/Form/DatePickerInput';
+import {
+    MAXIMUM_BIKRAM_SAMBAT_YEAR,
+    MINIMUM_BIKRAM_SAMBAT_YEAR,
+    getBikramSambatMonthLabel,
+    getGregorianMonthLabel,
+} from '../../../utils/date';
 
 vi.mock('../../../components/Popup', () => ({
     default: ({ children, isVisible }: { children: React.ReactNode; isVisible: boolean }) => {
@@ -312,5 +318,173 @@ describe('DatePickerInput customization hooks', () => {
         expect(container.querySelectorAll('.calendar-nav-button')).toHaveLength(2);
         expect(container.querySelectorAll('.calendar-weekday')[0]).toHaveTextContent('Mon');
         expect(container.querySelectorAll('.my-outside-day').length).toBeGreaterThan(0);
+    });
+});
+
+// BS spans AD 1918-04-13 to AD 2044-04-12; an AD selection outside it has no BS spelling.
+describe('DatePickerInput AD/BS toggle with a selection outside the BS range', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    const openToggleOptions = (container: HTMLElement) => {
+        fireEvent.focus(container.querySelector('input') as HTMLInputElement);
+        const [adOption, bsOption] = Array.from(
+            container.querySelectorAll('.date-system-toggle-option'),
+        ) as HTMLButtonElement[];
+        return { adOption, bsOption };
+    };
+
+    const windowOf = (container: HTMLElement) => ({
+        month: container.querySelector('.calendar-title-month')?.textContent,
+        year: container.querySelector('.calendar-title-year')?.textContent,
+    });
+
+    it('clamps the window to the BS maximum and keeps the AD value through a round trip', () => {
+        const { container } = render(
+            <DatePickerInput mode="toggle" value="2050-06-15" onChange={onChange} />,
+        );
+        const { adOption, bsOption } = openToggleOptions(container);
+
+        expect(windowOf(container)).toEqual({
+            month: getGregorianMonthLabel(6),
+            year: '2050',
+        });
+
+        expect(() => fireEvent.click(bsOption)).not.toThrow();
+
+        expect(windowOf(container)).toEqual({
+            month: getBikramSambatMonthLabel(12),
+            year: String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+        });
+        // The date has no BS spelling, so the field reads blank and no day may ghost as selected.
+        expect(container.querySelector('input')).toHaveValue('');
+        expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+        fireEvent.click(adOption);
+
+        expect(windowOf(container)).toEqual({
+            month: getGregorianMonthLabel(6),
+            year: '2050',
+        });
+        expect(container.querySelector('input')).toHaveValue('2050-06-15');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('15');
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('clamps the window to the BS minimum and keeps the AD value through a round trip', () => {
+        const { container } = render(
+            <DatePickerInput mode="toggle" value="1910-03-01" onChange={onChange} />,
+        );
+        const { adOption, bsOption } = openToggleOptions(container);
+
+        expect(() => fireEvent.click(bsOption)).not.toThrow();
+
+        expect(windowOf(container)).toEqual({
+            month: getBikramSambatMonthLabel(1),
+            year: String(MINIMUM_BIKRAM_SAMBAT_YEAR),
+        });
+        expect(container.querySelector('input')).toHaveValue('');
+        expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+        fireEvent.click(adOption);
+
+        expect(windowOf(container)).toEqual({
+            month: getGregorianMonthLabel(3),
+            year: '1910',
+        });
+        expect(container.querySelector('input')).toHaveValue('1910-03-01');
+        expect(container.querySelector('.calendar-day-selected')).toHaveTextContent('1');
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not commit the unspellable blank as a clear on blur', () => {
+        const { container } = render(
+            <DatePickerInput mode="toggle" value="2050-06-15" onChange={onChange} />,
+        );
+        const { adOption, bsOption } = openToggleOptions(container);
+        fireEvent.click(bsOption);
+
+        const input = container.querySelector('input') as HTMLInputElement;
+        fireEvent.blur(input);
+
+        expect(onChange).not.toHaveBeenCalled();
+
+        fireEvent.focus(input);
+        fireEvent.click(adOption);
+        expect(container.querySelector('input')).toHaveValue('2050-06-15');
+    });
+
+    it('does not commit the unspellable blank as a clear on Enter', () => {
+        const { container } = render(
+            <DatePickerInput mode="toggle" value="2050-06-15" onChange={onChange} />,
+        );
+        const { bsOption } = openToggleOptions(container);
+        fireEvent.click(bsOption);
+
+        fireEvent.keyDown(container.querySelector('input') as HTMLInputElement, {
+            key: 'Enter',
+        });
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(container.querySelector('input')).toHaveValue('');
+    });
+
+    it('keeps the value and both windows exact across repeated toggles', () => {
+        const { container } = render(
+            <DatePickerInput mode="toggle" value="2050-06-15" onChange={onChange} />,
+        );
+        const { adOption, bsOption } = openToggleOptions(container);
+
+        for (let round = 0; round < 4; round += 1) {
+            fireEvent.click(bsOption);
+            expect(windowOf(container)).toEqual({
+                month: getBikramSambatMonthLabel(12),
+                year: String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+            });
+            expect(container.querySelector('.calendar-day-selected')).toBeNull();
+
+            fireEvent.click(adOption);
+            expect(windowOf(container)).toEqual({
+                month: getGregorianMonthLabel(6),
+                year: '2050',
+            });
+            expect(container.querySelector('input')).toHaveValue('2050-06-15');
+        }
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('returns to the exact typed AD window across repeated clamped toggles with no selection', () => {
+        const { container } = render(<DatePickerInput mode="toggle" onChange={onChange} />);
+        const { adOption, bsOption } = openToggleOptions(container);
+
+        // A year past the BS range moves the window without selecting anything.
+        fireEvent.change(container.querySelector('input') as HTMLInputElement, {
+            target: { value: '2090-03' },
+        });
+        expect(windowOf(container)).toEqual({
+            month: getGregorianMonthLabel(3),
+            year: '2090',
+        });
+
+        for (let round = 0; round < 3; round += 1) {
+            fireEvent.click(bsOption);
+            expect(windowOf(container)).toEqual({
+                month: getBikramSambatMonthLabel(12),
+                year: String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+            });
+
+            // The clamp lands on the window only; the anchor still holds the chosen AD month.
+            fireEvent.click(adOption);
+            expect(windowOf(container)).toEqual({
+                month: getGregorianMonthLabel(3),
+                year: '2090',
+            });
+        }
+
+        expect(onChange).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/components/Inputs/DateTimePickerInput.test.tsx
+++ b/__tests__/components/Inputs/DateTimePickerInput.test.tsx
@@ -158,3 +158,30 @@ describe('DateTimePickerInput customization hooks', () => {
         expect(screen.getByTestId('day-19')).toHaveAttribute('data-disabled', 'false');
     });
 });
+
+describe('DateTimePickerInput blank commit with no date', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('resets and emits null when the date input blurs with a time but no date', () => {
+        const { container } = render(
+            <DateTimePickerInput timeMode="native" onChange={onChange} />,
+        );
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(container.querySelector('.date-time-field') as HTMLInputElement, {
+            target: { value: '10:30' },
+        });
+        expect(container.querySelector('.date-time-field')).toHaveValue('10:30');
+
+        onChange.mockClear();
+        fireEvent.blur(dateInput);
+
+        expect(onChange).toHaveBeenCalledWith({ name: undefined, value: null });
+        expect(container.querySelector('.date-time-field')).toHaveValue('');
+    });
+});

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 
 import {
     FiChevronLeft,
@@ -26,6 +32,7 @@ import {
     compareBikramSambatDates,
     compareGregorianDates,
     convertBikramSambatToGregorian,
+    convertGregorianToBikramSambat,
     getBikramSambatMonthLabel,
     getBikramSambatWeekdayLabel,
     getDaysInBikramSambatMonth,
@@ -37,6 +44,7 @@ import {
     isNepaliLanguage,
     isValidBikramSambatDate,
     isValidGregorianDate,
+    jsDateToGregorian,
     toNepaliDigits,
 } from "../../utils/date";
 import List, {
@@ -91,6 +99,76 @@ const VARIANT_CLASS_NAMES: Record<CalendarSystem, string> = {
     nepali: "nepali-calendar",
 };
 
+// BS's real convertible span is narrower than Gregorian's declared 1900-2100 range.
+const BIKRAM_SAMBAT_SUPPORTED_GREGORIAN_RANGE = {
+    minimum: convertBikramSambatToGregorian({
+        year: MINIMUM_BIKRAM_SAMBAT_YEAR,
+        month: 1,
+        day: 1,
+    }),
+    maximum: convertBikramSambatToGregorian({
+        year: MAXIMUM_BIKRAM_SAMBAT_YEAR,
+        month: 12,
+        day: getDaysInBikramSambatMonth(MAXIMUM_BIKRAM_SAMBAT_YEAR, 12),
+    }),
+};
+
+const convertViewDate = (
+    fromSystem: CalendarSystem,
+    toSystem: CalendarSystem,
+    date: CalendarDate,
+): CalendarDate => {
+    if (fromSystem === toSystem) {
+        return date;
+    }
+    if (fromSystem === "nepali") {
+        return jsDateToGregorian(convertBikramSambatToGregorian(date));
+    }
+    const asJsDate = gregorianToJsDate(date);
+    if (asJsDate < BIKRAM_SAMBAT_SUPPORTED_GREGORIAN_RANGE.minimum) {
+        return { year: MINIMUM_BIKRAM_SAMBAT_YEAR, month: 1, day: 1 };
+    }
+    if (asJsDate > BIKRAM_SAMBAT_SUPPORTED_GREGORIAN_RANGE.maximum) {
+        return { year: MAXIMUM_BIKRAM_SAMBAT_YEAR, month: 12, day: 1 };
+    }
+    return convertGregorianToBikramSambat(asJsDate);
+};
+
+// Clamps a year/month into [minimumBound, maximumBound], carrying month over/underflow into the year first.
+const clampMonthToBounds = (
+    year: number,
+    month: number,
+    minimumBound: CalendarDate,
+    maximumBound: CalendarDate,
+): { year: number; month: number } => {
+    if (month < 1) {
+        year -= 1;
+        month = 12;
+    } else if (month > 12) {
+        year += 1;
+        month = 1;
+    }
+    if (
+        year < minimumBound.year ||
+        (year === minimumBound.year && month < minimumBound.month)
+    ) {
+        return { year: minimumBound.year, month: minimumBound.month };
+    }
+    if (
+        year > maximumBound.year ||
+        (year === maximumBound.year && month > maximumBound.month)
+    ) {
+        return { year: maximumBound.year, month: maximumBound.month };
+    }
+    return { year, month };
+};
+
+interface VisibleWindow {
+    system: CalendarSystem;
+    year: number;
+    month: number;
+}
+
 interface NavigationOption {
     value: number;
     label: string;
@@ -121,7 +199,6 @@ interface AdjacentMonth {
     daysInMonth: number;
 }
 
-// Returns null past the date system's supported years, where day counts are unavailable.
 const getAdjacentMonth = (
     dateSystem: CalendarDateSystem,
     year: number,
@@ -209,42 +286,61 @@ const Calendar: React.FC<CalendarProps> = (props) => {
         return today;
     }, [dateSystem, value, today, minimumBound, maximumBound]);
 
-    const [visibleYear, setVisibleYear] = useState(initialDate.year);
-    const [visibleMonth, setVisibleMonth] = useState(initialDate.month);
+    const [visibleWindow, setVisibleWindow] = useState<VisibleWindow>(() => ({
+        system,
+        year: initialDate.year,
+        month: initialDate.month,
+    }));
+
+    const windowAnchorRef = useRef<{ system: CalendarSystem; date: CalendarDate }>({
+        system,
+        date: initialDate,
+    });
+
+    let visibleYear = visibleWindow.year;
+    let visibleMonth = visibleWindow.month;
+    if (visibleWindow.system !== system) {
+        const anchor = windowAnchorRef.current;
+        const target = dateSystem.isValid(value)
+            ? (value as CalendarDate)
+            : convertViewDate(anchor.system, system, anchor.date);
+        const clamped = clampMonthToBounds(
+            target.year,
+            target.month,
+            minimumBound,
+            maximumBound,
+        );
+        visibleYear = clamped.year;
+        visibleMonth = clamped.month;
+        setVisibleWindow({ system, year: visibleYear, month: visibleMonth });
+    }
 
     useEffect(() => {
         if (dateSystem.isValid(value)) {
-            setVisibleYear((value as CalendarDate).year);
-            setVisibleMonth((value as CalendarDate).month);
+            const selected = value as CalendarDate;
+            windowAnchorRef.current = { system, date: selected };
+            setVisibleWindow({
+                system,
+                year: selected.year,
+                month: selected.month,
+            });
         }
-    }, [dateSystem, value]);
+    }, [dateSystem, system, value]);
 
     const navigateToMonth = useCallback(
         (year: number, month: number) => {
-            if (month < 1) {
-                year -= 1;
-                month = 12;
-            } else if (month > 12) {
-                year += 1;
-                month = 1;
-            }
-            if (
-                year < minimumBound.year ||
-                (year === minimumBound.year && month < minimumBound.month)
-            ) {
-                year = minimumBound.year;
-                month = minimumBound.month;
-            } else if (
-                year > maximumBound.year ||
-                (year === maximumBound.year && month > maximumBound.month)
-            ) {
-                year = maximumBound.year;
-                month = maximumBound.month;
-            }
-            setVisibleYear(year);
-            setVisibleMonth(month);
+            const clamped = clampMonthToBounds(year, month, minimumBound, maximumBound);
+            windowAnchorRef.current = {
+                system,
+                date: { year: clamped.year, month: clamped.month, day: 1 },
+            };
+            setVisibleWindow({
+                system,
+                year: clamped.year,
+                month: clamped.month,
+            });
         },
-        [minimumBound, maximumBound],
+        [system, minimumBound, maximumBound],
     );
 
     useEffect(() => {

--- a/components/Calendar/usePickerDateField.tsx
+++ b/components/Calendar/usePickerDateField.tsx
@@ -174,13 +174,18 @@ const usePickerDateField = <Model,>(
         model.parseIso(value ?? defaultValue),
     );
     const resetBaseline = selected;
-    const [inputText, setInputText] = useState<string>(() =>
-        model.format(
+    const [inputState, setInputState] = useState<{
+        system: DisplaySystem;
+        text: string;
+    }>(() => ({
+        system: mode === "nepali" ? "bs" : "ad",
+        text: model.format(
             model.parseIso(value ?? defaultValue),
             mode === "nepali" ? "bs" : "ad",
             language,
         ),
-    );
+    }));
+    const inputText = inputState.text;
     const [expanded, setExpanded] = useState(false);
     const [warning, setWarning] = useState<string | null>(null);
 
@@ -195,9 +200,10 @@ const usePickerDateField = <Model,>(
     }, [value]);
 
     useEffect(() => {
-        setInputText(
-            modelRef.current.format(selected, displaySystem, language),
-        );
+        setInputState({
+            system: displaySystem,
+            text: modelRef.current.format(selected, displaySystem, language),
+        });
     }, [selected, displaySystem, language]);
 
     useEffect(() => {
@@ -295,7 +301,10 @@ const usePickerDateField = <Model,>(
     const commitTypedValue = useCallback((): "committed" | "reset" => {
         const trimmedText = inputText.trim();
         if (trimmedText === "") {
-            if (!model.equals(selected, model.empty)) {
+            const isBlankByDisplay =
+                !!model.getDate(selected) &&
+                model.format(selected, displaySystem, language) === "";
+            if (!model.equals(selected, model.empty) && !isBlankByDisplay) {
                 setSelected(model.empty);
                 emit(model.empty);
             }
@@ -311,7 +320,10 @@ const usePickerDateField = <Model,>(
             }
             return "committed";
         }
-        setInputText(model.format(resetBaseline, displaySystem, language));
+        setInputState({
+            system: displaySystem,
+            text: model.format(resetBaseline, displaySystem, language),
+        });
         return "reset";
     }, [
         inputText,
@@ -326,10 +338,10 @@ const usePickerDateField = <Model,>(
 
     const handleInputChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
-            setInputText(event.target.value);
+            setInputState({ system: displaySystem, text: event.target.value });
             showCalendar();
         },
-        [showCalendar],
+        [displaySystem, showCalendar],
     );
 
     const handleKeyDown = useCallback(
@@ -347,8 +359,11 @@ const usePickerDateField = <Model,>(
     );
 
     const typedViewParts = useMemo(
-        () => parseCalendarViewParts(inputText, displaySystem),
-        [inputText, displaySystem],
+        () =>
+            inputState.system === displaySystem
+                ? parseCalendarViewParts(inputState.text, displaySystem)
+                : undefined,
+        [inputState, displaySystem],
     );
 
     const errorText = useMemo(() => {


### PR DESCRIPTION
Fixes issue where toggling between AD and BS would not convert date windows if no date was selected.

- [x] Convert visible year/month through AD<->BS when the system changes with no value.
- [x] Anchor each conversion to the last window the user actually chose, kept in its own system.
- [x] Fixes the "Mangsir 2026" style mismatch and the one-month-back drift per toggle round trip.
- [x] Clamp to the nearest BS boundary instead of throwing on Gregorian years with no BS match.
- [x] Add regression tests for round trips, repeated toggles, both directions, BS bounds, selection.