### PR TITLE
fix(datetimepicker): keep typed date when a time is entered

### DIFF
--- a/__tests__/components/Inputs/DateTimePickerInput.test.tsx
+++ b/__tests__/components/Inputs/DateTimePickerInput.test.tsx
@@ -159,6 +159,123 @@ describe('DateTimePickerInput customization hooks', () => {
     });
 });
 
+describe('DateTimePickerInput uncommitted typed date', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('keeps a typed date that has not been committed when a time is typed', () => {
+        const { container } = render(
+            <DateTimePickerInput timeMode="native" onChange={onChange} />,
+        );
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '2024-01-15' } });
+
+        fireEvent.change(container.querySelector('.date-time-field') as HTMLInputElement, {
+            target: { value: '10:30' },
+        });
+
+        expect(onChange).not.toHaveBeenCalledWith({ name: undefined, value: null });
+        expect(onChange).toHaveBeenLastCalledWith({ name: undefined, value: '2024-01-15T10:30' });
+        expect(container.querySelector('.date-time-field')).toHaveValue('10:30');
+        expect(dateInput).toHaveValue('2024-01-15 10:30');
+    });
+
+    it('keeps a typed date that has not been committed when a time option is picked', () => {
+        const { container } = render(<DateTimePickerInput onChange={onChange} />);
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '2024-01-15' } });
+
+        fireEvent.click(screen.getByText('10:30'));
+
+        expect(onChange).not.toHaveBeenCalledWith({ name: undefined, value: null });
+        expect(onChange).toHaveBeenLastCalledWith({ name: undefined, value: '2024-01-15T10:30' });
+        expect(dateInput).toHaveValue('2024-01-15 10:30');
+    });
+
+    it('reverts an unparseable typed date to the committed value when a time is typed', () => {
+        const { container } = render(
+            <DateTimePickerInput timeMode="native" value="2024-01-15T10:00" onChange={onChange} />,
+        );
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '2024-01' } });
+
+        fireEvent.change(container.querySelector('.date-time-field') as HTMLInputElement, {
+            target: { value: '11:30' },
+        });
+
+        expect(onChange).not.toHaveBeenCalledWith({ name: undefined, value: null });
+        expect(onChange).toHaveBeenLastCalledWith({ name: undefined, value: '2024-01-15T11:30' });
+    });
+});
+
+describe('DateTimePickerInput single emit per time entry', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('emits null once when the date text is erased before a time option is picked', () => {
+        const { container } = render(
+            <DateTimePickerInput value="2024-01-15T10:00" onChange={onChange} />,
+        );
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '' } });
+
+        fireEvent.click(screen.getByText('11:30'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith({ name: undefined, value: null });
+    });
+
+    it('does not surface the typed time when a different time option is picked', () => {
+        const { container } = render(<DateTimePickerInput onChange={onChange} />);
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '2024-01-15 10:30' } });
+
+        fireEvent.click(screen.getByText('11:30'));
+
+        expect(onChange).not.toHaveBeenCalledWith({ name: undefined, value: '2024-01-15T10:30' });
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith({ name: undefined, value: '2024-01-15T11:30' });
+    });
+
+    it('still emits the committed typed value when the entered time is out of bounds', () => {
+        const { container } = render(
+            <DateTimePickerInput
+                timeMode="native"
+                value="2024-01-15T10:00"
+                minimumDate="2024-01-15T10:00"
+                onChange={onChange}
+            />,
+        );
+
+        const dateInput = container.querySelector('input') as HTMLInputElement;
+        fireEvent.focus(dateInput);
+        fireEvent.change(dateInput, { target: { value: '2024-01-15 10:30' } });
+
+        fireEvent.change(container.querySelector('.date-time-field') as HTMLInputElement, {
+            target: { value: '09:30' },
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith({ name: undefined, value: '2024-01-15T10:30' });
+    });
+});
+
 describe('DateTimePickerInput blank commit with no date', () => {
     const onChange = vi.fn();
 

--- a/components/Calendar/usePickerDateField.tsx
+++ b/components/Calendar/usePickerDateField.tsx
@@ -56,6 +56,11 @@ export interface PickerDateFieldModel<Model> {
     isComplete?: (model: Model) => boolean;
 }
 
+export interface CommitTypedValueResult<Model> {
+    status: "committed" | "reset";
+    model: Model;
+}
+
 interface UsePickerDateFieldConfig<Model> {
     name?: string;
     value?: string | null;
@@ -113,7 +118,8 @@ export interface PickerDateField<Model> {
     handleInputFocus: () => void;
     handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-    commitTypedValue: () => "committed" | "reset";
+    /** Commits typed text. Use the returned model, not `selected`, which is stale until re-render. */
+    commitTypedValue: () => CommitTypedValueResult<Model>;
     handleClearIconClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     emit: (model: Model) => void;
     systemToggle: React.ReactNode;
@@ -298,7 +304,7 @@ const usePickerDateField = <Model,>(
         [model, completesOnDateChange, hideCalendar, emit],
     );
 
-    const commitTypedValue = useCallback((): "committed" | "reset" => {
+    const commitTypedValue = useCallback((): CommitTypedValueResult<Model> => {
         const trimmedText = inputText.trim();
         if (trimmedText === "") {
             const isBlankByDisplay =
@@ -307,8 +313,9 @@ const usePickerDateField = <Model,>(
             if (!model.equals(selected, model.empty) && !isBlankByDisplay) {
                 setSelected(model.empty);
                 emit(model.empty);
+                return { status: "committed", model: model.empty };
             }
-            return "committed";
+            return { status: "committed", model: selected };
         }
         const parsed = model.parseTyped(trimmedText, displaySystem);
         const parsedDate = parsed ? model.getDate(parsed) : null;
@@ -318,13 +325,13 @@ const usePickerDateField = <Model,>(
                 setSelected(parsed);
                 emit(parsed);
             }
-            return "committed";
+            return { status: "committed", model: parsed };
         }
         setInputState({
             system: displaySystem,
             text: model.format(resetBaseline, displaySystem, language),
         });
-        return "reset";
+        return { status: "reset", model: resetBaseline };
     }, [
         inputText,
         displaySystem,
@@ -348,7 +355,7 @@ const usePickerDateField = <Model,>(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
             if (event.key === "Enter") {
                 event.preventDefault();
-                if (commitTypedValue() === "committed") {
+                if (commitTypedValue().status === "committed") {
                     hideCalendar();
                 }
             } else if (event.key === "Escape" || event.key === "Tab") {

--- a/components/Form/DateTimePickerInput/index.tsx
+++ b/components/Form/DateTimePickerInput/index.tsx
@@ -31,6 +31,11 @@ interface DateTimeModel {
     time: string;
 }
 
+interface DateTimeChangePayload {
+    name?: string;
+    value: string | null;
+}
+
 const parseTimeToMinutes = (time: string): number | null => {
     const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
     if (!match) {
@@ -223,14 +228,20 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
     );
 
     const timeInputRef = useRef<HTMLInputElement>(null);
+    const deferCommitEmitRef = useRef(false);
+    const deferredCommitPayloadRef = useRef<DateTimeChangePayload | null>(null);
 
     // A datetime is only meaningful once both date and time exist; suppress the intermediate date-only value.
     const handleChange = useCallback(
-        (payload: { name?: string; value: string | null }) => {
+        (payload: DateTimeChangePayload) => {
             if (
                 payload.value !== null &&
                 !payload.value.includes(ISO_DATETIME_SEPARATOR)
             ) {
+                return;
+            }
+            if (deferCommitEmitRef.current) {
+                deferredCommitPayloadRef.current = payload;
                 return;
             }
             onChange?.(payload);
@@ -271,37 +282,60 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
         completesOnDateChange: false,
     });
 
-    const { Wrapper, wrapperProps, setSelected, emit, hideCalendar } = field;
+    const {
+        Wrapper,
+        wrapperProps,
+        setSelected,
+        emit,
+        hideCalendar,
+        commitTypedValue,
+    } = field;
     const selectedDate = field.selectedDate;
     const timeText = field.selected.time;
 
     const useNepaliDigits =
         field.displaySystem === "bs" && isNepaliLanguage(language);
 
+    // The date input can still hold typed text; commit it first so entering a time never discards it.
+    const applyTime = useCallback(
+        (time: string): DateTimeModel | null => {
+            deferredCommitPayloadRef.current = null;
+            deferCommitEmitRef.current = true;
+            let committed: DateTimeModel;
+            try {
+                committed = commitTypedValue().model;
+            } finally {
+                deferCommitEmitRef.current = false;
+            }
+            if (
+                time &&
+                committed.date &&
+                !isWithinBounds(committed.date, time)
+            ) {
+                const deferredPayload = deferredCommitPayloadRef.current;
+                if (deferredPayload) {
+                    onChange?.(deferredPayload);
+                }
+                return null;
+            }
+            const next: DateTimeModel = { date: committed.date, time };
+            setSelected(next);
+            emit(next);
+            return next;
+        },
+        [commitTypedValue, isWithinBounds, setSelected, emit, onChange],
+    );
+
     const handleTimeChange = useCallback(
         (target: HTMLInputElement) => {
-            const raw = target.value;
-            if (raw === "") {
-                const next: DateTimeModel = { date: selectedDate, time: "" };
-                setSelected(next);
-                emit(next);
-                return;
-            }
-            const normalized = normalizeTime(raw) || raw;
-            if (!selectedDate || isWithinBounds(selectedDate, normalized)) {
-                const next: DateTimeModel = {
-                    date: selectedDate,
-                    time: normalized,
-                };
-                setSelected(next);
-                emit(next);
-                return;
-            }
-            if (timeInputRef.current) {
+            const rawTime = target.value;
+            const normalizedTime =
+                rawTime === "" ? "" : normalizeTime(rawTime) || rawTime;
+            if (!applyTime(normalizedTime) && timeInputRef.current) {
                 timeInputRef.current.value = timeText;
             }
         },
-        [selectedDate, timeText, isWithinBounds, setSelected, emit],
+        [applyTime, timeText],
     );
 
     const timeOptions = useMemo<TimeOption[]>(() => {
@@ -327,19 +361,11 @@ const DateTimePickerInput: React.FC<DateTimePickerInputProps> = (props) => {
 
     const handleTimeOptionSelect = useCallback(
         (option: TimeOption) => {
-            if (!selectedDate || isWithinBounds(selectedDate, option.time)) {
-                const next: DateTimeModel = {
-                    date: selectedDate,
-                    time: option.time,
-                };
-                setSelected(next);
-                emit(next);
-                if (selectedDate) {
-                    hideCalendar();
-                }
+            if (applyTime(option.time)?.date) {
+                hideCalendar();
             }
         },
-        [selectedDate, isWithinBounds, setSelected, emit, hideCalendar],
+        [applyTime, hideCalendar],
     );
 
     const onMinimumBoundaryDate =


### PR DESCRIPTION
- [x] Keep the typed date when a time is entered before the date is committed.
- [x] Leave a time with no date still clearing the field, as before.
- [x] Cover date-then-time entry with tests.