### PR TITLE
fix(popup): keep focus inside popups that open outside a modal

### DIFF
--- a/__tests__/components/Inputs/SelectInput.test.tsx
+++ b/__tests__/components/Inputs/SelectInput.test.tsx
@@ -140,6 +140,95 @@ describe('SelectInput', () => {
         });
     });
 
+    describe('opening on focus', () => {
+        const getWrapper = (container: HTMLElement) =>
+            container.querySelector(`.${styles.selectContainer}`) as HTMLElement;
+
+        it('opens when the user presses the select', async () => {
+            const { container } = renderSelect();
+            const wrapper = getWrapper(container);
+
+            await act(async () => {
+                fireEvent.mouseDown(wrapper);
+                wrapper.focus();
+            });
+
+            expect(screen.getByTestId('popup')).toBeInTheDocument();
+        });
+
+        it('opens when the user tabs into the select', async () => {
+            const { container } = renderSelect();
+            const wrapper = getWrapper(container);
+
+            await act(async () => {
+                fireEvent.keyDown(document.body, { key: 'Tab' });
+                wrapper.focus();
+            });
+
+            expect(screen.getByTestId('popup')).toBeInTheDocument();
+        });
+
+        it('stays closed when focus arrives without a user gesture', async () => {
+            const { container } = render(
+                <>
+                    <button type="button" data-testid="other-control">
+                        Other
+                    </button>
+                    <SelectInput
+                        options={OPTIONS}
+                        keyExtractor={keyExtractor}
+                        valueExtractor={valueExtractor}
+                        onChange={onChange}
+                    />
+                </>,
+            );
+            const wrapper = getWrapper(container);
+
+            await act(async () => {
+                screen.getByTestId('other-control').focus();
+            });
+            // A focus trap reclaiming focus looks like this: a real relatedTarget, no pointer or key press behind it.
+            await act(async () => {
+                wrapper.focus();
+            });
+
+            expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+        });
+
+        it('stays closed when a key press that landed elsewhere is followed by programmatic focus', async () => {
+            const { container } = render(
+                <>
+                    <button type="button" data-testid="other-control">
+                        Other
+                    </button>
+                    <SelectInput
+                        options={OPTIONS}
+                        keyExtractor={keyExtractor}
+                        valueExtractor={valueExtractor}
+                        onChange={onChange}
+                    />
+                </>,
+            );
+            const wrapper = getWrapper(container);
+
+            // Tabbing onto something that is not a select leaves that key press unclaimed.
+            await act(async () => {
+                fireEvent.keyDown(document.body, { key: 'Tab' });
+                screen.getByTestId('other-control').focus();
+            });
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+
+            // A focus trap redirecting focus later must not inherit that key press.
+            await act(async () => {
+                wrapper.focus();
+            });
+
+            expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+        });
+    });
+
     describe('clear functionality', () => {
         it('manages clear visibility and triggers onChange with null', () => {
             const { container } = renderSelect({ value: OPTIONS[0], name: 'mySelect' });

--- a/__tests__/components/PickerModalFocusTrap.test.tsx
+++ b/__tests__/components/PickerModalFocusTrap.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DatePickerInput from '../../components/Form/DatePickerInput';
+import DateTimePickerInput from '../../components/Form/DateTimePickerInput';
+import SelectInput from '../../components/Form/SelectInput';
+import Modal from '../../components/Modal';
+
+// react-focus-lock is left unmocked: a stubbed FocusLock cannot show how the real trap treats a portalled popup.
+
+const noop = () => {};
+
+const SERVICES = [
+    { id: '1', label: 'General Medicine' },
+    { id: '2', label: 'Orthopedic' },
+];
+
+const renderInModal = (picker: React.ReactNode) =>
+    render(
+        <Modal isVisible onClose={noop}>
+            <SelectInput
+                options={SERVICES}
+                keyExtractor={(item) => item.id}
+                valueExtractor={(item) => item.label}
+                onChange={noop}
+            />
+            {picker}
+        </Modal>,
+    );
+
+// The trap pulls focus back from a deferred timer, so the yank only shows up after it runs.
+const flushFocusTrap = async () => {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+};
+
+const openMonthOptions = async (popupSelector: string) => {
+    const popup = document.querySelector(popupSelector) as HTMLElement;
+    const navigationButton = popup.querySelector('.calendar-nav-button') as HTMLElement;
+
+    // Any control inside the calendar will do: it is the first thing to move focus out of the modal's own DOM.
+    act(() => {
+        navigationButton.focus();
+    });
+
+    const monthSelect = popup.querySelector('.calendar-header-select') as HTMLElement;
+    const monthSearch = monthSelect.querySelector('input') as HTMLInputElement;
+
+    act(() => {
+        fireEvent.mouseDown(monthSearch);
+        monthSearch.focus();
+    });
+    await flushFocusTrap();
+
+    return monthSearch;
+};
+
+describe('Picker calendar inside a modal', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('keeps focus inside the date calendar when its month dropdown opens', async () => {
+        renderInModal(
+            <DatePickerInput
+                value="2024-01-15"
+                onChange={noop}
+                calendarProps={{ enableMonthDropdown: true }}
+            />,
+        );
+
+        const dateInput = document.querySelector('.date-input') as HTMLInputElement;
+        act(() => {
+            dateInput.focus();
+        });
+        expect(document.querySelector('.date-popup')).toBeInTheDocument();
+
+        const monthSearch = await openMonthOptions('.date-popup');
+
+        expect(document.activeElement).toBe(monthSearch);
+        expect(document.querySelector('.date-popup')).toContainElement(
+            document.activeElement as HTMLElement,
+        );
+        // The month options popup, and nothing else, opened on top of the calendar.
+        expect(document.querySelectorAll('.popup')).toHaveLength(2);
+    });
+
+    it('keeps focus inside the date time calendar when its month dropdown opens', async () => {
+        renderInModal(
+            <DateTimePickerInput
+                value="2024-01-15T10:00"
+                onChange={noop}
+                timeStepMinutes={60}
+                calendarProps={{ enableMonthDropdown: true }}
+            />,
+        );
+
+        const dateTimeInput = document.querySelector('.date-time-input') as HTMLInputElement;
+        act(() => {
+            dateTimeInput.focus();
+        });
+        expect(document.querySelector('.date-time-popup')).toBeInTheDocument();
+
+        const monthSearch = await openMonthOptions('.date-time-popup');
+
+        expect(document.activeElement).toBe(monthSearch);
+        expect(document.querySelector('.date-time-popup')).toContainElement(
+            document.activeElement as HTMLElement,
+        );
+        expect(document.querySelectorAll('.popup')).toHaveLength(2);
+    });
+
+    it('still returns focus to the picker input when the calendar closes', async () => {
+        renderInModal(
+            <DatePickerInput
+                value="2024-01-15"
+                onChange={noop}
+                calendarProps={{ enableMonthDropdown: true }}
+            />,
+        );
+
+        const dateInput = document.querySelector('.date-input') as HTMLInputElement;
+        act(() => {
+            dateInput.focus();
+        });
+
+        const day = Array.from(document.querySelectorAll('.date-popup button')).find(
+            (button) => button.textContent === '20',
+        ) as HTMLElement;
+        act(() => {
+            fireEvent.click(day);
+        });
+        await flushFocusTrap();
+
+        expect(document.querySelector('.date-popup')).not.toBeInTheDocument();
+        expect(document.activeElement).toBe(dateInput);
+    });
+
+    it('keeps the picker text input typeable while the calendar is open', async () => {
+        renderInModal(<DatePickerInput value="2024-01-15" onChange={noop} />);
+
+        const dateInput = document.querySelector('.date-input') as HTMLInputElement;
+        act(() => {
+            dateInput.focus();
+        });
+        expect(document.querySelector('.date-popup')).toBeInTheDocument();
+
+        act(() => {
+            fireEvent.change(dateInput, { target: { value: '2024-02-20' } });
+        });
+        await flushFocusTrap();
+
+        expect(document.activeElement).toBe(dateInput);
+        expect(dateInput).toHaveValue('2024-02-20');
+    });
+});

--- a/__tests__/components/Popup.test.tsx
+++ b/__tests__/components/Popup.test.tsx
@@ -14,15 +14,33 @@ vi.mock('../../components/Portal', () => ({
     default: ({ children }: { children: React.ReactNode }) => <div data-testid='portal'>{children}</div>,
 }));
 
+type FocusLockNode = HTMLElement & { shards?: HTMLElement[] };
+
 vi.mock('react-focus-lock', () => ({
-    default: ({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) => (
-        <div data-testid='focus-lock' data-disabled={disabled}>
+    default: ({
+        children,
+        disabled,
+        shards,
+    }: {
+        children: React.ReactNode;
+        disabled?: boolean;
+        shards?: HTMLElement[];
+    }) => (
+        <div
+            data-testid='focus-lock'
+            data-disabled={disabled}
+            ref={(node: FocusLockNode | null) => {
+                if (node) node.shards = shards;
+            }}
+        >
             {children}
         </div>
     ),
 }));
 
 const mockUseRect = useRect as Mock;
+
+const getShards = (lock: HTMLElement) => (lock as FocusLockNode).shards ?? [];
 
 const defaultAnchorRect = {
     top: 100,
@@ -298,6 +316,56 @@ describe('Popup', () => {
 
             const focusLock = screen.getByTestId('focus-lock');
             expect(focusLock).toHaveAttribute('data-disabled', 'true');
+        });
+    });
+
+    describe('Focus lock shards', () => {
+        const NestedPopups = ({ nested = true }: { nested?: boolean }) => {
+            const anchorRef = useRef<HTMLButtonElement>(null);
+            const nestedAnchorRef = useRef<HTMLButtonElement>(null);
+
+            return (
+                <>
+                    <button ref={anchorRef} data-testid='anchor-button'>
+                        Anchor
+                    </button>
+                    <Popup anchor={anchorRef} onClose={mockOnClose} disableFocusLock>
+                        <div data-testid='popup-content'>
+                            <button ref={nestedAnchorRef} data-testid='nested-anchor'>
+                                Nested anchor
+                            </button>
+                            {nested && (
+                                <Popup anchor={nestedAnchorRef} onClose={mockOnClose}>
+                                    <div data-testid='nested-content'>Nested Content</div>
+                                </Popup>
+                            )}
+                        </div>
+                    </Popup>
+                </>
+            );
+        };
+
+        it('starts with no shards when nothing is portalled inside the popup', () => {
+            render(<TestComponent />);
+
+            expect(getShards(screen.getByTestId('focus-lock'))).toHaveLength(0);
+        });
+
+        it('registers a nested popup as a shard of the popup that owns it', () => {
+            render(<NestedPopups />);
+
+            const [outerLock] = screen.getAllByTestId('focus-lock');
+            const nestedWrapper = screen.getByTestId('nested-content').parentElement;
+
+            expect(getShards(outerLock)).toEqual([nestedWrapper]);
+        });
+
+        it('drops the shard again when the nested popup unmounts', () => {
+            const { rerender } = render(<NestedPopups />);
+
+            rerender(<NestedPopups nested={false} />);
+
+            expect(getShards(screen.getByTestId('focus-lock'))).toHaveLength(0);
         });
     });
 

--- a/components/Form/SelectInput/focusIntent.ts
+++ b/components/Form/SelectInput/focusIntent.ts
@@ -1,0 +1,62 @@
+type FocusIntent = { kind: 'pointer'; target: Node | null } | { kind: 'keyboard' };
+
+let pendingIntent: FocusIntent | null = null;
+let expiryTimeout: ReturnType<typeof setTimeout> | null = null;
+let observerCount = 0;
+
+const clearIntent = () => {
+    pendingIntent = null;
+    if (expiryTimeout !== null) {
+        clearTimeout(expiryTimeout);
+        expiryTimeout = null;
+    }
+};
+
+// The browser moves focus while still handling the gesture, so anything focused in a later task was not the user.
+const armIntent = (intent: FocusIntent) => {
+    clearIntent();
+    pendingIntent = intent;
+    expiryTimeout = setTimeout(clearIntent, 0);
+};
+
+const handlePointerDown = (event: MouseEvent) => {
+    armIntent({ kind: 'pointer', target: event.target as Node | null });
+};
+
+const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Tab') {
+        armIntent({ kind: 'keyboard' });
+    }
+};
+
+// Records the pointer/keyboard gesture that a following focus event can be attributed to.
+export function observeFocusIntent() {
+    if (observerCount === 0) {
+        document.addEventListener('mousedown', handlePointerDown, true);
+        document.addEventListener('keydown', handleKeyDown, true);
+    }
+    observerCount += 1;
+
+    return () => {
+        observerCount -= 1;
+        if (observerCount === 0) {
+            document.removeEventListener('mousedown', handlePointerDown, true);
+            document.removeEventListener('keydown', handleKeyDown, true);
+            clearIntent();
+        }
+    };
+}
+
+// Whether focus on `wrapper` came from the user; consumes the gesture so one gesture opens at most one select.
+export function consumeFocusIntent(wrapper: HTMLElement | null) {
+    const intent = pendingIntent;
+    clearIntent();
+
+    if (!intent) {
+        return false;
+    }
+    if (intent.kind === 'keyboard') {
+        return true;
+    }
+    return !!wrapper && !!intent.target && wrapper.contains(intent.target);
+}

--- a/components/Form/SelectInput/index.tsx
+++ b/components/Form/SelectInput/index.tsx
@@ -4,6 +4,7 @@ import { FiChevronDown } from 'react-icons/fi';
 import { FaSpinner } from 'react-icons/fa';
 import { IoMdClose } from 'react-icons/io';
 
+import { consumeFocusIntent, observeFocusIntent } from './focusIntent';
 import Options from './Options';
 import styles from './styles.module.scss';
 import type { SelectInputProps } from './types';
@@ -262,9 +263,8 @@ function Select<T, V extends ReactNode>(props: SelectInputProps<T, V>) {
     );
 
     const handleSelectFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
-        // Skip focus events where relatedTarget is null — this happens when the previously
-        // focused element was removed from the DOM (e.g. FocusLock returnFocus after a Popup unmounts).
-        if (event.relatedTarget === null) {
+        // FocusLock also moves focus programmatically with a relatedTarget set, so open only on a real user gesture.
+        if (!consumeFocusIntent(wrapperRef.current)) {
             return;
         }
         if (!disabled) {
@@ -318,6 +318,8 @@ function Select<T, V extends ReactNode>(props: SelectInputProps<T, V>) {
             };
         });
     },[options, getFocusedItem, filterOptions, onInputChange]);
+
+    useEffect(() => observeFocusIntent(), []);
 
     useEffect(() => {
         updateSelectValue();

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -6,6 +6,7 @@ import type { ModalProps } from './types';
 import Portal from '../Portal';
 import withVisibleCheck from '../WithVisibleCheck';
 import cs from '../../cs';
+import { FocusShardContext, useFocusShardHost } from '../../hooks/useFocusShards';
 
 const Modal: React.FC<ModalProps> = (props) => {
     const {
@@ -19,6 +20,8 @@ const Modal: React.FC<ModalProps> = (props) => {
     } = props;
 
     const wrapperRef = useRef<HTMLDivElement>(null);
+
+    const { shards: focusShards, registry: focusShardRegistry } = useFocusShardHost();
 
     const className = cs(styles.modal, classNameFromProps, 'modal');
     const overlayClassName = cs(styles.overlay, overlayClassNameFromProps, 'overlay');
@@ -67,13 +70,15 @@ const Modal: React.FC<ModalProps> = (props) => {
 
     return (
         <Portal>
-            <FocusLock disabled={disableFocusLock}>
-                <div className={overlayClassName} data-testid="modal-overlay">
-                    <div ref={wrapperRef} className={className}>
-                        {children}
+            <FocusShardContext.Provider value={focusShardRegistry}>
+                <FocusLock disabled={disableFocusLock} shards={focusShards}>
+                    <div className={overlayClassName} data-testid="modal-overlay">
+                        <div ref={wrapperRef} className={className}>
+                            {children}
+                        </div>
                     </div>
-                </div>
-            </FocusLock>
+                </FocusLock>
+            </FocusShardContext.Provider>
         </Portal>
     );
 };

--- a/components/Popup/README.md
+++ b/components/Popup/README.md
@@ -37,6 +37,23 @@ That target also doubles as the boundary the popup is kept inside of (see
 below) — pass `container` explicitly when the popup should stay clipped to a
 scrollable panel rather than the whole viewport.
 
+### Focus and enclosing focus traps
+
+Because the popup portals out of its React parent's DOM, it also lands outside the
+focus trap of any enclosing `Modal`. A trap that cannot see the popup pulls focus
+back to the modal's first tabbable element as soon as anything inside the popup is
+focused, which reads as focus jumping out of the popup for no visible reason.
+
+`Popup` avoids that by registering its own wrapper with every enclosing trap as a
+`react-focus-lock` shard, so focus inside the popup counts as focus inside those
+traps. That happens automatically and covers nested popups too, whether or not the
+popup owns a trap of its own via `disableFocusLock`.
+
+Anything else that portals content out of a `Modal` needs the same treatment: use
+`useFocusShard` from `hooks/useFocusShards` to register the portalled node, and
+`useFocusShardHost` when the component owns a trap that portalled descendants
+should register with.
+
 ### Keeping the popup on screen
 
 Position isn't just the static `anchorOrigin`/`transformOrigin` calculation —

--- a/components/Popup/index.tsx
+++ b/components/Popup/index.tsx
@@ -14,6 +14,7 @@ import {
 import Portal from '../Portal';
 import withVisibleCheck from '../WithVisibleCheck';
 import cs from '../../cs';
+import { FocusShardContext, useFocusShard, useFocusShardHost } from '../../hooks/useFocusShards';
 import useRect from '../../hooks/useRect';
 import { isNullOrUndefined, isResizeObserverAvailable } from '../../utils';
 
@@ -52,6 +53,10 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
     const [wrapperStyle, setWrapperStyle] = useState<React.CSSProperties>();
+    const [wrapperNode, setWrapperNode] = useState<HTMLDivElement | null>(null);
+
+    const { shards: focusShards, registry: focusShardRegistry } = useFocusShardHost();
+    useFocusShard(wrapperNode);
 
     const anchorRect = useRect(anchor.current);
     const viewportRect = useRect(viewportElement);
@@ -165,6 +170,7 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
 
     const handleWrapperRef = useCallback((node: HTMLDivElement | null) => {
         wrapperRef.current = node;
+        setWrapperNode(node);
 
         resizeObserverRef.current?.disconnect();
         resizeObserverRef.current = null;
@@ -210,13 +216,15 @@ function Popup<T extends HTMLElement | null>(props: PopupProps<T>) {
     return (
         <Portal container={portalContainer}>
             <PopupNestingContext.Provider value={nestingContextValue}>
-                <FocusLock disabled={disableFocusLock} returnFocus>
-                    {wrapperStyle && (
-                        <div ref={handleWrapperRef} className={className} style={wrapperStyle}>
-                            {children}
-                        </div>
-                    )}
-                </FocusLock>
+                <FocusShardContext.Provider value={focusShardRegistry}>
+                    <FocusLock disabled={disableFocusLock} returnFocus shards={focusShards}>
+                        {wrapperStyle && (
+                            <div ref={handleWrapperRef} className={className} style={wrapperStyle}>
+                                {children}
+                            </div>
+                        )}
+                    </FocusLock>
+                </FocusShardContext.Provider>
             </PopupNestingContext.Provider>
         </Portal>
     );

--- a/hooks/useFocusShards.ts
+++ b/hooks/useFocusShards.ts
@@ -1,0 +1,49 @@
+import { createContext, useContext, useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface FocusShardRegistry {
+    /**
+     * Registers a node that renders outside the owning focus trap's DOM subtree - typically a
+     * portalled popup - as a `react-focus-lock` shard, so the trap counts focus landing inside
+     * that node as focus inside itself instead of pulling it back.
+     *
+     * Returns an unregister function.
+     */
+    registerFocusShard: (node: HTMLElement) => () => void;
+}
+
+export const FocusShardContext = createContext<FocusShardRegistry | null>(null);
+
+// For focus trap owners: collects shard nodes from portalled descendants and forwards them to enclosing traps.
+export function useFocusShardHost() {
+    const enclosingRegistry = useContext(FocusShardContext);
+    const [shards, setShards] = useState<HTMLElement[]>([]);
+
+    const registerFocusShard = useCallback(
+        (node: HTMLElement) => {
+            setShards((prev) => (prev.includes(node) ? prev : [...prev, node]));
+            const unregisterFromEnclosing = enclosingRegistry?.registerFocusShard(node);
+
+            return () => {
+                setShards((prev) => prev.filter((shard) => shard !== node));
+                unregisterFromEnclosing?.();
+            };
+        },
+        [enclosingRegistry],
+    );
+
+    const registry = useMemo<FocusShardRegistry>(() => ({ registerFocusShard }), [registerFocusShard]);
+
+    return { shards, registry };
+}
+
+// Used by portalled content: keeps `node` registered as a shard of every enclosing focus trap.
+export function useFocusShard(node: HTMLElement | null) {
+    const enclosingRegistry = useContext(FocusShardContext);
+
+    useEffect(() => {
+        if (!node || !enclosingRegistry) {
+            return;
+        }
+        return enclosingRegistry.registerFocusShard(node);
+    }, [node, enclosingRegistry]);
+}


### PR DESCRIPTION
- [x] A date picker's month or year dropdown in a modal no longer moves focus out of the calendar.
- [x] No second, unrelated dropdown opens alongside it.
- [x] A popup rendered outside a modal now counts as inside that modal's focus trap.
- [x] Selects only open on a real click or key press, not on focus moved for them.
- [x] Typing in the picker input and closing the calendar still behave as before.