### PR TITLE
fix(styles): inherit the app font on buttons

### DIFF
--- a/styles/_reset.scss
+++ b/styles/_reset.scss
@@ -15,3 +15,7 @@ html {
   /* smooth scroll */
   scroll-behavior: smooth;
 }
+
+button {
+  font: inherit;
+}


### PR DESCRIPTION
- [x] Buttons now inherit the app font instead of the browser default.
- [x] Fixes calendar day cells and the picker clear icon rendering in the wrong font.