### PR TITLE
fix(calendar): keep the visible month valid across system switches

### DIFF
--- a/__tests__/components/Calendar.test.tsx
+++ b/__tests__/components/Calendar.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -840,8 +842,7 @@ describe('Calendar (AD/BS toggle with a viewDate held across the system change)'
         onChange.mockClear();
     });
 
-    // Only the round trip is pinned: an untagged viewDate held across the change still steers the BS leg.
-    it('returns to the exact AD window across repeated toggles', () => {
+    it('ignores the stale-system viewDate and shows the clamp target, then returns to the exact AD window', () => {
         const viewDate = { year: 2090, month: 3 };
 
         const { rerender, container } = render(
@@ -856,6 +857,13 @@ describe('Calendar (AD/BS toggle with a viewDate held across the system change)'
                 );
             }).not.toThrow();
 
+            expect(container.querySelector('.calendar-title-year')).toHaveTextContent(
+                String(MAXIMUM_BIKRAM_SAMBAT_YEAR),
+            );
+            expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+                getBikramSambatMonthLabel(12),
+            );
+
             rerender(
                 <Calendar system="gregorian" value={null} viewDate={viewDate} onChange={onChange} />,
             );
@@ -865,6 +873,77 @@ describe('Calendar (AD/BS toggle with a viewDate held across the system change)'
             expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2090');
         }
 
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('still applies a fresh viewDate supplied together with the system change', () => {
+        const { rerender, container } = render(
+            <Calendar
+                system="gregorian"
+                value={null}
+                viewDate={{ year: 2081, month: 1 }}
+                onChange={onChange}
+            />,
+        );
+
+        rerender(
+            <Calendar
+                system="nepali"
+                value={null}
+                viewDate={{ year: 2082, month: 6 }}
+                onChange={onChange}
+            />,
+        );
+
+        expect(container.querySelector('.calendar-title-year')).toHaveTextContent('2082');
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(6),
+        );
+    });
+});
+
+describe('Calendar (windowAnchorRef precedence over value on a system switch)', () => {
+    const onChange = vi.fn();
+
+    beforeEach(() => {
+        onChange.mockClear();
+    });
+
+    it('paints the browsed-to anchor, not the selected value, on the commit before the sync effect runs', () => {
+        const adValue = { year: 2026, month: 8, day: 15 };
+        const bsValue = convertGregorianToBikramSambat(
+            new Date(adValue.year, adValue.month - 1, adValue.day),
+        );
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const root = createRoot(container);
+
+        flushSync(() => {
+            root.render(<Calendar system="gregorian" value={adValue} onChange={onChange} />);
+        });
+
+        flushSync(() => {
+            fireEvent.click(screen.getByLabelText('Next month'));
+        });
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getGregorianMonthLabel(9),
+        );
+
+        flushSync(() => {
+            root.render(<Calendar system="nepali" value={bsValue} onChange={onChange} />);
+        });
+
+        const browsedToBs = convertGregorianToBikramSambat(new Date(2026, 8, 1));
+        expect(container.querySelector('.calendar-title-month')).toHaveTextContent(
+            getBikramSambatMonthLabel(browsedToBs.month),
+        );
+        expect(container.querySelector('.calendar-title-month')).not.toHaveTextContent(
+            getBikramSambatMonthLabel(bsValue.month),
+        );
+
+        root.unmount();
+        container.remove();
         expect(onChange).not.toHaveBeenCalled();
     });
 });

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -301,9 +301,7 @@ const Calendar: React.FC<CalendarProps> = (props) => {
     let visibleMonth = visibleWindow.month;
     if (visibleWindow.system !== system) {
         const anchor = windowAnchorRef.current;
-        const target = dateSystem.isValid(value)
-            ? (value as CalendarDate)
-            : convertViewDate(anchor.system, system, anchor.date);
+        const target = convertViewDate(anchor.system, system, anchor.date);
         const clamped = clampMonthToBounds(
             target.year,
             target.month,
@@ -343,8 +341,21 @@ const Calendar: React.FC<CalendarProps> = (props) => {
         [system, minimumBound, maximumBound],
     );
 
+    const viewDateOriginRef = useRef<{
+        system: CalendarSystem;
+        year?: number;
+        month?: number;
+    }>({ system, year: viewDate?.year, month: viewDate?.month });
+
     useEffect(() => {
+        const origin = viewDateOriginRef.current;
+        const isUnchanged =
+            origin.year === viewDate?.year && origin.month === viewDate?.month;
+        viewDateOriginRef.current = { system, year: viewDate?.year, month: viewDate?.month };
         if (!viewDate) {
+            return;
+        }
+        if (isUnchanged && origin.system !== system) {
             return;
         }
         const targetYear =


### PR DESCRIPTION
- [x] Land on valid month when switching between AD and BS views, not a stale or impossible one.
- [x] A leftover display month from before the switch no longer overrides that correction.